### PR TITLE
Remove `decorate()` dependency from `isoDateFromDateInput` filter

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -97,18 +97,57 @@ You submitted your application at 4:32pm.
 
 ## isoDateFromDateInput
 
-Convert decorated `govukDateInput` values to an ISO 8601 date.
+The `govukDateInput` component stores separate values for `day`, `month` and `year` values.
 
-The `decorate()` method applied to a `govukDateInput` creates an object with `day`, `month` and `year` values. This filter will convert this into an ISO 8601 formatted date.
+When prefixed using a `namePrefix`, these values are stored with names prefixed with that value. This filter takes these prefixed values and converts them into an ISO 8601 formatted date.
 
 Input
 
+```js
+const data = {
+  `dob-day`: '01',
+  `dob-month`: '02',
+  `dob-year`: '2012',
+}
+```
+
 ```njk
-{{ { day: '17', month: '08', year: '2021' } | isoDateFromDateInput }}
+{{ data | isoDateFromDateInput("dob") }}
 ```
 
 Output
 
 ```html
-2021-08-17
+2012-02-01
+```
+
+Combine this filter with `govukDate` to output a human readable date:
+
+```njk
+{{ data | isoDateFromDateInput("dob") | govukDate }}
+```
+
+```html
+1 February 2012
+```
+
+It’s possible to configure `govukDateInput` so that only certain parts of a date are asked for, such as a month and year. You can also omit the `namePrefix` option and use individual `name` options for each value if you want to save them in a nested object. This filter also covers that use case:
+
+```js
+const data = {
+  passport: {
+    month: '5',
+    year: '2001',
+  }
+}
+```
+
+```njk
+{{ data.passport | isoDateFromDateInput }}
+```
+
+Output
+
+```html
+2001-05
 ```

--- a/lib/date.js
+++ b/lib/date.js
@@ -119,35 +119,55 @@ function govukTime (string) {
 }
 
 /**
- * Convert decorated `govukDateInput` values to an ISO 8601 date.
+ * Convert `govukDateInput` values to an ISO 8601 date.
  *
- * The `decorate()` method applied to a `govukDateInput` creates an object with
- * `day`, `month` and `year` values. We can convert this into ISO 8601 format.
+ * The `govukDateInput` creates separate values for its component for `day`,
+ * `month` and `year` values, optionally prefixed with a `namePrefix`.
  *
- * @example <caption>Full date</caption>
- * isoDateFromDateInput({ day: '17', month: '08', year: '2021' }) // 2021-08-17
+ * `namePrefix` is optional, and intended for the simplistic use case where
+ * date values are saved at the top level of prototype session data.
  *
- * @example <caption>Month and year only</caption>
- * isoDateFromDateInput({ month: '08', year: '2021' }) // 2021-08
+ * If no `namePrefix` is provided, assumes author is setting custom names for
+ * each component value and storing session data in a nested object.
  *
- * @param {object} object - Date object
- * @returns {string} `object` converted to a ISO 8601 date string
+ * @example <caption>With namePrefix</caption>
+ * data = {
+ *   'dob-day': '01',
+ *   'dob-month': '02',
+ *   'dob-year: '2012'
+ * }
+ * isoDateFromDateInput(data, 'dob') // 2012-02-01
+ *
+ * @example <caption>Without namePrefix, month and year only</caption>
+ * data = {
+ *   issued: {
+ *     month: '02',
+ *     year: '2012'
+ *   }
+ * }
+ * isoDateFromDateInput(data.issued) // 2012-02
+ *
+ * @param {object} object - Object containing date values
+ * @param {string} [namePrefix] - `namePrefix` used for date values
+ * @returns {string} ISO 8601 date string
  */
-function isoDateFromDateInput (object) {
-  object = normalize(object, '')
+function isoDateFromDateInput (object, namePrefix) {
+  let day, month, year
 
-  if (typeof object !== 'object') {
-    return object
+  if (namePrefix) {
+    day = Number(object[`${namePrefix}-day`])
+    month = Number(object[`${namePrefix}-month`])
+    year = Number(object[`${namePrefix}-year`])
+  } else {
+    day = Number(object?.day)
+    month = Number(object?.month)
+    year = Number(object?.year)
   }
 
   try {
-    const year = parseInt(object.year) || new Date().getFullYear()
-    const month = parseInt(object.month)
-
-    if (!object.day) {
+    if (!day) {
       return DateTime.local(year, month).toFormat('yyyy-LL')
     } else {
-      const day = parseInt(object.day)
       return DateTime.local(year, month, day).toISODate()
     }
   } catch (error) {

--- a/tests/date.mjs
+++ b/tests/date.mjs
@@ -36,22 +36,22 @@ test('Returns error converting an ISO 8601 date time to a time using the GOV.UK 
   t.is(govukTime('2021-08-17T25:61:00'), 'Invalid DateTime')
 })
 
-test('Converts decorated `govukDateInput` values to an ISO 8601 date', t => {
+test('Converts `govukDateInput` values to ISO 8601 date', t => {
   t.is(isoDateFromDateInput({
-    day: '17',
-    month: '08',
-    year: '2021'
-  }), '2021-08-17')
-  t.is(isoDateFromDateInput({
-    month: '08',
-    year: '2021'
-  }), '2021-08')
+    day: '01',
+    month: '02',
+    year: '2012'
+  }), '2012-02-01')
 })
 
-test('Doesn’t covert value to an ISO 8601 date if not an object', t => {
-  t.is(isoDateFromDateInput('2021-08-17T12:49:05'), '2021-08-17T12:49:05')
+test('Converts `govukDateInput` values with `namePrefix` to ISO 8601 date', t => {
+  t.is(isoDateFromDateInput({
+    'example-day': '01',
+    'example-month': '02',
+    'example-year': '2012'
+  }, 'example'), '2012-02-01')
 })
 
-test('Returns error converting decorated `govukDateInput` values to an ISO 8601 date', t => {
+test('Returns error converting `govukDateInput` values to an ISO 8601 date', t => {
   t.is(isoDateFromDateInput({ foo: 'bar' }), 'Invalid DateTime')
 })


### PR DESCRIPTION
Previously the `isoDateFromDateInput` depended on the `decorate` global function, now [found in the `govuk-decorated-components` package](https://github.com/x-govuk/govuk-decorated-components/blob/5f773024bb178bfff67c05b8a92dd69ea8976769/lib/decorate.js#L71). This combined values used in `govukDateInput` and stored them in a single object:

```js
data = {
  dob: {
    day: 1
    month: 2,
    year: 2012,
  }
}
```

This PR changes removes the dependency on that function and package so that it can provide out-of-the-box support for the GOV.UK Prototype Kit.

## Using a `namePrefix`

Assuming you had a prototype with a single form to capture date of birth, using the `govukDateInput` component with the `namePrefix` option set to `dob`:

```njk
{{ govukDateInput({
  id: "dob",
  namePrefix: "dob",
  fieldset: {
    legend: {
      text: "What is your date of birth?",
      isPageHeading: true,
      classes: "govuk-fieldset__legend--l"
    }
  }
}) }}
```

You would get the following in your session data:

```js
data = {
  'dob-day': '1'
  'dob-month': '2',
  'dob-year': 2012'
}
```

This filter can take this data and the `namePrefix` used and generate an ISO8601 date:

```njk
{{ data | isoDateFromDateInput("dob") }}

// 2012-02-01
```

You can combine this filter with `govukDate` to output a human readable date:

```njk
{{ data | isoDateFromDateInput("dob") | govukDate }}

// 1 February 2012
```

## Advanced component usage without `namePrefix`

In cases of more advanced usage of the `govukDateInput` component, where individual date components are configured with `name` options set so that values can be stored in a nested object, you can use this filter without providing a `namePrefix`:

```njk
{{ govukDateInput({
  id: "issued",
  fieldset: {
    legend: {
      text: "When was your passport issed?",
      isPageHeading: true,
      classes: "govuk-fieldset__legend--l"
    }
  },
  items: [{
    label: "Month",
    name: "issued[month]",
    classes: "govuk-input--width-2"
  }, {
    label: "Year",
    name: "issued[year]",
    classes: "govuk-input--width-4"
  }]
}) }}
```

```js
data = {
  issued: {
    month: '5',
    year: 2022'
  }
}
```

```njk
{{ data.issued | isoDateFromDateInput }}

// 2002-05
```

The filter assumes that you are still using `day`, `month` and `year` as the individual key names… which I think is okay?