### PR TITLE
Ensure `sterling` filter follows GOV.UK style guide

### DIFF
--- a/docs/number.md
+++ b/docs/number.md
@@ -41,20 +41,34 @@ fourth
 
 ## sterling
 
-Convert a number into a string formatted as pound sterling. This can be useful for converting numbers into a human readable price.
+Convert a number into a string formatted as pound sterling and that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money).
 
 Input
 
 ```njk
 {{ 81932 | sterling }}
 {{ 133.66667 | sterling }}
-{{ 6.83 | sterling }}
+{{ 75.50 | sterling }}
+{{ 75.00 | sterling }}
 ```
 
 Output
 
 ```html
-£81,932.00
+£81,932
 £133.67
-£6.83
+£75.50
+£75
+```
+
+The GOV.UK style guide recommends not using decimals unless pence are included. If you always want to use decimals (for example, to help compare values in a table), include `true` in the filter’s parameter:
+
+```njk
+{{ 75.00 | sterling(true) }}
+```
+
+Output
+
+```html
+£75.00
 ```

--- a/lib/number.js
+++ b/lib/number.js
@@ -68,23 +68,39 @@ function ordinal (number) {
 }
 
 /**
- * Convert a number into a string formatted as pound sterling.
+ * Convert a number into a string formatted as pound sterling that follows the
+ * GOV.UK style.
+ *
+ * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money}
  *
  * @example
- * sterling(81932) // £81,932.00
+ * sterling(81932) // £81,932
  * sterling(133.66667) // £133.67
- * sterling(6.83) // £6.83
+ * sterling(75.50) // £75.50
+ * sterling(75.00) // £75
+ * sterling(75.00, true) // £75.00
  *
  * @param {number} number - Value to convert
+ * @param {boolean} [trailingZeroIfInteger=false] - Include trailing zeros
  * @returns {string} `number` formatted as pound sterling
  */
-function sterling (number) {
+function sterling (number, trailingZeroIfInteger = false) {
   number = normalize(number, '')
 
-  return new Intl.NumberFormat('en-GB', {
+  let sterling = new Intl.NumberFormat('en-GB', {
     style: 'currency',
     currency: 'GBP'
   }).format(number)
+
+  /**
+   * TODO: Use options.trailingZeroDisplay once this package requires Node v20
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#trailingzerodisplay}
+   */
+  if (!trailingZeroIfInteger) {
+    sterling = sterling.replace(/\.00$/, '')
+  }
+
+  return sterling
 }
 
 module.exports = {

--- a/tests/number.mjs
+++ b/tests/number.mjs
@@ -16,7 +16,9 @@ test('Converts a number into an ordinal numeral', t => {
 })
 
 test('Converts a number into a string formatted as pound sterling', t => {
-  t.is(sterling(81932), '£81,932.00')
+  t.is(sterling(81932), '£81,932')
   t.is(sterling(133.66667), '£133.67')
-  t.is(sterling(6.83), '£6.83')
+  t.is(sterling(75.50), '£75.50')
+  t.is(sterling(75.00), '£75')
+  t.is(sterling(75.00, true), '£75.00')
 })


### PR DESCRIPTION
Updates `sterling` filter so that decimals are not shown if the resulting value doesn’t include pence:

```njk
{{ 75.00 | sterling }} // £75
```

However, if you want to always include decimals, you can provide a `true` parameter:

```njk
{{ 75.00 | sterling(true) }} // £75.00
```

Right now, trailing zeros are removed using `string.replace()`. Node 19+ supports the [`trailingZeroDisplay` option on `Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#trailingzerodisplay), so once this package requires a Node version greater than v20 (the next stable Node release that supports this option), this option can be used instead. I’ve included a note to this effect.

Fixes #7. Reported by @chris-barrett-ddts 