### PR TITLE
Add `monthName` filter

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -151,3 +151,33 @@ Output
 ```html
 2001-05
 ```
+
+## monthName
+
+Convert a number (between 1 and 12) to the name of the corresponding month.
+
+Input
+
+```njk
+{{ 3 | monthName }}
+```
+
+Output
+
+```html
+March
+```
+
+You can also output a truncated month name:
+
+Input
+
+```njk
+{{ 3 | monthName("truncate") }}
+```
+
+Output
+
+```html
+Mar
+```

--- a/lib/date.js
+++ b/lib/date.js
@@ -175,13 +175,38 @@ function isoDateFromDateInput (object, namePrefix) {
   }
 }
 
+/**
+ * Convert a number into name of corresponding month.
+ *
+ * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates}
+ *
+ * @example
+ * month(3) // March
+ * month(3, 'truncate') // Mar
+ *
+ * @param {number|string} number - Value to convert
+ * @param {boolean|string} [format=false] - Truncate name
+ * @returns {string} Month name
+ */
+function monthName (number, format = false) {
+  const monthIndex = Number(number) - 1
+  const date = new Date(2012, monthIndex)
+  const truncate = format === 'truncate'
+
+  return new Intl.DateTimeFormat('en-GB', {
+    month: truncate ? 'short' : 'long'
+  }).format(date)
+}
+
 module.exports = {
   govukDate,
   govukTime,
-  isoDateFromDateInput
+  isoDateFromDateInput,
+  monthName
 }
 
 // Add date filters to GOV.UK Prototype Kit
 views.addFilter('govukDate', govukDate)
 views.addFilter('govukTime', govukTime)
 views.addFilter('isoDateFromDateInput', isoDateFromDateInput)
+views.addFilter('monthName', monthName)

--- a/tests/date.mjs
+++ b/tests/date.mjs
@@ -2,7 +2,8 @@ import test from 'ava'
 import {
   govukDate,
   govukTime,
-  isoDateFromDateInput
+  isoDateFromDateInput,
+  monthName
 } from '../lib/date.js'
 
 const now = Date.now()
@@ -54,4 +55,11 @@ test('Converts `govukDateInput` values with `namePrefix` to ISO 8601 date', t =>
 
 test('Returns error converting `govukDateInput` values to an ISO 8601 date', t => {
   t.is(isoDateFromDateInput({ foo: 'bar' }), 'Invalid DateTime')
+})
+
+test('Converts a number into name of corresponding month.', t => {
+  t.is(monthName(3), 'March')
+  t.is(monthName('3'), 'March')
+  t.is(monthName(3, "truncate"), 'Mar')
+  t.is(monthName('3', "truncate"), 'Mar')
 })


### PR DESCRIPTION
There is prior art for such a filter:

* DfE’s Manage teacher training applications prototype has a [`prettyMonth` filter](https://github.com/DFE-Digital/manage-teacher-training-applications-prototype/blob/e7105e60eeba64a49218d35645859083c163b87b/app/filters/dates.js#L166)
* Defra’s `extra-filters` library has a [`toMonth` filter](https://github.com/defra-design/extra-filters/blob/627101e976ba2025afb573b346c5df938f8af300/extra-filters.js#L45)

This filter, simply called `month`, takes a number and uses `Intl.DateFormat` to get the month name for the corresponding month number.

This might be a slightly more complex method than necessary, but it does mean that in the future, alternative languages (for example Welsh) could be supported fairly easily by supplying a language code as an option to the filter.