### PR TITLE
Add `duration` filter

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -3,6 +3,22 @@ title: Date filters
 order: 2
 ---
 
+## dateFromNow
+
+Return a date a certain number of days from now.
+
+Input
+
+```njk
+{{ 5 | dateFromNow }}
+```
+
+Output
+
+```html
+2023-05-14
+```
+
 ## govukDate
 
 Convert an ISO 8601 date time to a human readable date that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates).

--- a/docs/date.md
+++ b/docs/date.md
@@ -3,20 +3,78 @@ title: Date filters
 order: 2
 ---
 
-## dateFromNow
+## duration
 
-Return a date a certain number of days from now.
+Returns a date a certain number of days from another date. 
 
 Input
 
 ```njk
-{{ 5 | dateFromNow }}
+{{ "2023-05-11" | duration(5, "days") }}
 ```
 
 Output
 
 ```html
-2023-05-14T09:00:59
+2023-05-16T00:00:00.000+01:00
+```
+
+Input
+
+```njk
+{{ "2023-05-11" | duration(5, "weeks") }}
+```
+
+Output
+
+```html
+2023-06-15T00:00:00.000+01:00
+```
+
+Input
+
+```njk
+{{ "2023-05-11" | duration(5, "months") }}
+```
+Output
+
+```html
+2023-10-11T00:00:00.000+01:00
+```
+
+Input
+
+```njk
+{{ "2023-05-11" | duration(5, "years") }}
+```
+Output
+
+```html
+2028-05-11T00:00:00.000+01:00
+```
+
+To returns a date from todays date, pass the special word `"today"` (or `"now"`):
+
+Input
+
+```njk
+{{ "today" | duration(5, "days") }}
+```
+Output
+```html
+2023-05-11T09:00:59
+```
+
+If a unit is not passed the second parameter the unit will default to days
+
+Input
+
+```njk
+{{ "today" | duration(5) }}
+```
+Output
+```html
+2023-05-11T09:00:59
 ```
 
 ## govukDate

--- a/docs/date.md
+++ b/docs/date.md
@@ -16,7 +16,7 @@ Input
 Output
 
 ```html
-2023-05-14
+2023-05-14T09:00:59
 ```
 
 ## govukDate

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,8 +1,22 @@
 const { views } = require('govuk-prototype-kit')
-const { DateTime, Settings } = require('luxon')
+const { DateTime, Duration, Settings } = require('luxon')
 const { normalize } = require('./utils.js')
 
 Settings.throwOnInvalid = true
+
+/**
+ * Return a date a certain number of days from now.
+ *
+ * @example dateFromNow(5) // 2023-05-14
+ *
+ * @param {number} number of days to add
+ * @returns {string} ISO 8601 date string
+ */
+function dateFromNow (number) {
+  const now = DateTime.now()
+  const dur = Duration.fromObject({ days: number })
+  return now.plus(dur)
+}
 
 /**
  * Convert an ISO 8601 date time to a human readable date that follows the
@@ -182,6 +196,7 @@ module.exports = {
 }
 
 // Add date filters to GOV.UK Prototype Kit
+views.addFilter('dateFromNow', dateFromNow)
 views.addFilter('govukDate', govukDate)
 views.addFilter('govukTime', govukTime)
 views.addFilter('isoDateFromDateInput', isoDateFromDateInput)

--- a/lib/date.js
+++ b/lib/date.js
@@ -5,17 +5,46 @@ const { normalize } = require('./utils.js')
 Settings.throwOnInvalid = true
 
 /**
- * Return a date a certain number of days from now.
+ * Returns a date a certain number of days from another date.
  *
- * @example dateFromNow(5) // 2023-05-14T09:00:59
+ * @example <caption>Days from today</caption>
+ * duration('today', 5, 'days') // 2023-06-15T16:28:56.082+01:00
  *
+ * @example <caption>Days from date</caption>
+ * duration('2023-05-11', 5, 'days') // 2023-05-16T00:00:00.000+01:00
+ *
+ * @example <caption>Weeks from date</caption>
+ * duration('2023-05-11', 5, 'weeks') // 2023-06-15T00:00:00.000+01:00
+ *
+ * @example <caption>Months from date</caption>
+ * duration('2023-05-11', 5, 'months') // 2023-10-11T00:00:00.000+01:00
+ *
+ * @example <caption>Years from date</caption>
+ * duration('2023-05-11', 5, 'years') // 2028-05-11T00:00:00.000+01:00
+ *
+ * @param {string} string - Date
  * @param {number} number of days to add
+ * @param {string} [unit] the type of units to use
  * @returns {string} ISO 8601 date string
  */
-function dateFromNow (number) {
-  const now = DateTime.now()
-  const dur = Duration.fromObject({ days: number })
-  return now.plus(dur).toString()
+function duration (string, number, unit) {
+  string = normalize(string, '')
+  try {
+    if (string === 'today' || string === 'now') {
+      string = DateTime.now().toString()
+    }
+
+    // default unit to days
+    if (unit === undefined) {
+      unit = 'days'
+    }
+
+    const date = DateTime.fromISO(string)
+    const dur = Duration.fromObject({ [unit]: number })
+    return date.plus(dur).toString()
+  } catch (error) {
+    return error.message.split(':')[0]
+  }
 }
 
 /**
@@ -190,14 +219,14 @@ function isoDateFromDateInput (object, namePrefix) {
 }
 
 module.exports = {
-  dateFromNow,
+  duration,
   govukDate,
   govukTime,
   isoDateFromDateInput
 }
 
 // Add date filters to GOV.UK Prototype Kit
-views.addFilter('dateFromNow', dateFromNow)
+views.addFilter('duration', duration)
 views.addFilter('govukDate', govukDate)
 views.addFilter('govukTime', govukTime)
 views.addFilter('isoDateFromDateInput', isoDateFromDateInput)

--- a/lib/date.js
+++ b/lib/date.js
@@ -28,10 +28,11 @@ Settings.throwOnInvalid = true
  * @returns {string} ISO 8601 date string
  */
 function duration (string, number, unit) {
+  const timeZone = 'Europe/London'
   string = normalize(string, '')
   try {
     if (string === 'today' || string === 'now') {
-      string = DateTime.now().toString()
+      string = DateTime.now().setZone(timeZone).toString()
     }
 
     // default unit to days
@@ -39,7 +40,7 @@ function duration (string, number, unit) {
       unit = 'days'
     }
 
-    const date = DateTime.fromISO(string)
+    const date = DateTime.fromISO(string, { zone: timeZone })
     const dur = Duration.fromObject({ [unit]: number })
     return date.plus(dur).toString()
   } catch (error) {

--- a/lib/date.js
+++ b/lib/date.js
@@ -7,7 +7,7 @@ Settings.throwOnInvalid = true
 /**
  * Return a date a certain number of days from now.
  *
- * @example dateFromNow(5) // 2023-05-14
+ * @example dateFromNow(5) // 2023-05-14T09:00:59
  *
  * @param {number} number of days to add
  * @returns {string} ISO 8601 date string
@@ -15,7 +15,7 @@ Settings.throwOnInvalid = true
 function dateFromNow (number) {
   const now = DateTime.now()
   const dur = Duration.fromObject({ days: number })
-  return now.plus(dur)
+  return now.plus(dur).toString()
 }
 
 /**
@@ -190,6 +190,7 @@ function isoDateFromDateInput (object, namePrefix) {
 }
 
 module.exports = {
+  dateFromNow,
   govukDate,
   govukTime,
   isoDateFromDateInput

--- a/tests/date.mjs
+++ b/tests/date.mjs
@@ -11,7 +11,7 @@ const now = Date.now()
 test('Adds 5 days to todays date', t => {
   const dt = new Date()
   dt.setDate(dt.getDate() + 5)
-  t.is(String(dateFromNow(5)).substring(0, 10), dt.toISOString().substring(0, 10))
+  t.is((dateFromNow(5)).substring(0, 10), dt.toISOString().substring(0, 10))
 })
 
 test('Converts an ISO 8601 date time to a date using the GOV.UK style', t => {

--- a/tests/date.mjs
+++ b/tests/date.mjs
@@ -1,11 +1,18 @@
 import test from 'ava'
 import {
+  dateFromNow,
   govukDate,
   govukTime,
   isoDateFromDateInput
 } from '../lib/date.js'
 
 const now = Date.now()
+
+test('Adds 5 days to todays date', t => {
+  const dt = new Date()
+  dt.setDate(dt.getDate() + 5)
+  t.is(String(dateFromNow(5)).substring(0, 10), dt.toISOString().substring(0, 10))
+})
 
 test('Converts an ISO 8601 date time to a date using the GOV.UK style', t => {
   t.is(govukDate('2021-08-17'), '17 August 2021')

--- a/tests/date.mjs
+++ b/tests/date.mjs
@@ -1,6 +1,6 @@
 import test from 'ava'
 import {
-  dateFromNow,
+  duration,
   govukDate,
   govukTime,
   isoDateFromDateInput
@@ -8,10 +8,19 @@ import {
 
 const now = Date.now()
 
-test('Adds 5 days to todays date', t => {
+test('Return a date a certain number of days from another date', t => {
   const dt = new Date()
   dt.setDate(dt.getDate() + 5)
-  t.is((dateFromNow(5)).substring(0, 10), dt.toISOString().substring(0, 10))
+  t.is((duration('today', 5)).substring(0, 10), dt.toISOString().substring(0, 10))
+  t.is((duration('2023-05-11', 5)), '2023-05-16T00:00:00.000+01:00')
+  t.is((duration('2023-05-11', 5, 'days')), '2023-05-16T00:00:00.000+01:00')
+  t.is((duration('2023-05-11', 5, 'weeks')), '2023-06-15T00:00:00.000+01:00')
+  t.is((duration('2023-05-11', 5, 'months')), '2023-10-11T00:00:00.000+01:00')
+  t.is((duration('2023-05-11', 5, 'years')), '2028-05-11T00:00:00.000+01:00')
+})
+
+test('Returns error trying to return a date from another date', t => {
+  t.is(duration('2021-23-45', 5), 'Invalid DateTime')
 })
 
 test('Converts an ISO 8601 date time to a date using the GOV.UK style', t => {


### PR DESCRIPTION
This is a filter to get the date a certain number of days from todays date.

This is useful if you're displaying an SLA on a confirmation page, by giving the user an actual date rather than leaving them to work out when 5 days from now is.

It uses the Luxon Duration object.