### PR TITLE
Refactor `currency` filter

### DIFF
--- a/docs/number.md
+++ b/docs/number.md
@@ -3,6 +3,91 @@ title: Number filters
 order: 3
 ---
 
+## currency
+
+Convert a number into a string formatted as currency.
+
+Input
+
+```njk
+{{ 133.66667 | currency }}
+{{ 75.5 | currency }}
+{{ 75 | currency }}
+```
+
+Output
+
+```html
+£133.67
+£75.50
+£75.00
+```
+
+### Options
+
+#### `display`
+
+Use the `display` option to change how the currency is displayed. Accepts the following values:
+
+* `"narrowSymbol"`: use a narrow format symbol, for example ‘$100’.
+* `"symbol"`: use a localized currency symbol, for example ‘US$100’.
+* `"code"`: use the ISO 4217 currency code, for example ‘USD $75.00’.
+* `"name"`: use a localised currency name, for example ‘75.00 US dollars’.
+
+Default is `"symbol"`.
+
+Input
+
+```njk
+{{ 75 | currency(display="narrowSymbol", unit="USD") }}
+{{ 75 | currency(display="symbol", unit="USD") }}
+{{ 75 | currency(display="code", unit="USD") }}
+{{ 75 | currency(display="name", unit="USD") }}
+```
+
+Output
+
+```html
+$75.00
+US$75.00
+USD $75.00
+75.00 US dollars
+```
+
+#### `trailingZeros`
+
+Use the `trailingZeros` option to show leading zeros for whole number values. Default is `true`.
+
+> Set this option to `false` to display pounds and pence in a format that follows [the GOV.UK style for money](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money).
+
+Input
+
+```njk
+{{ 75.0015 | currency(trailingZeros=false) }}
+```
+
+Output
+
+```html
+£75
+```
+
+#### `unit`
+
+Use the `unit` option to change the unit of currency. Accepts an [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217). Default is `"GBP"`.
+
+Input
+
+```njk
+{{ 75 | currency(unit="USD") }}
+```
+
+Output
+
+```html
+US$75.00
+```
+
 ## isNumber
 
 Checks if a value is classified as a [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) primitive or object.
@@ -37,38 +122,4 @@ Output
 ```html
 fourth
 22nd
-```
-
-## sterling
-
-Convert a number into a string formatted as pound sterling and that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money).
-
-Input
-
-```njk
-{{ 81932 | sterling }}
-{{ 133.66667 | sterling }}
-{{ 75.50 | sterling }}
-{{ 75.00 | sterling }}
-```
-
-Output
-
-```html
-£81,932
-£133.67
-£75.50
-£75
-```
-
-The GOV.UK style guide recommends not using decimals unless pence are included. If you always want to use decimals (for example, to help compare values in a table), include `true` in the filter’s parameter:
-
-```njk
-{{ 75.00 | sterling(true) }}
-```
-
-Output
-
-```html
-£75.00
 ```

--- a/lib/number.js
+++ b/lib/number.js
@@ -3,6 +3,51 @@ const _ = require('lodash')
 const { normalize } = require('./utils.js')
 
 /**
+ * Convert a number into a string formatted as a currency.
+ *
+ * @example
+ * currency(81932) // £81,932
+ * currency(133.66667) // £133.67
+ * currency(75.5) // £75.50
+ * currency(75, { format: 'code' }) // GBP 75.00
+ * currency(75, { trailingZeroIfInteger: false }) // £75
+ * currency(75, { unit: 'USD' }) // $75.00
+ *
+ * @param {number} number - Value to convert
+ * @param {object} [kwargs] - Keyword arguments
+ * @param {string} [kwargs.display=narrowSymbol] - Currency display
+ * @param {boolean} [kwargs.trailingZeros=true] - Include trailing .00
+ * @param {string} [kwargs.unit=GBP] - Currency unit
+ * @returns {string} `number` formatted as currency
+ */
+function currency (number, kwargs) {
+  number = normalize(number, '')
+
+  const options = {
+    display: 'symbol',
+    trailingZeros: true,
+    unit: 'GBP',
+    ...kwargs
+  }
+
+  let currency = new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: options.unit,
+    currencyDisplay: options.display
+  }).format(number)
+
+  /**
+   * TODO: Use options.trailingZeroDisplay once this package requires Node v20
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#trailingzerodisplay}
+   */
+  if (!options.trailingZeros) {
+    currency = currency.replace(/\.00$/, '')
+  }
+
+  return currency
+}
+
+/**
  * Check if a value is classified as a `Number` primitive or object.
  *
  * @example
@@ -67,49 +112,13 @@ function ordinal (number) {
   return `${number}${suffix}`
 }
 
-/**
- * Convert a number into a string formatted as pound sterling that follows the
- * GOV.UK style.
- *
- * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money}
- *
- * @example
- * sterling(81932) // £81,932
- * sterling(133.66667) // £133.67
- * sterling(75.50) // £75.50
- * sterling(75.00) // £75
- * sterling(75.00, true) // £75.00
- *
- * @param {number} number - Value to convert
- * @param {boolean} [trailingZeroIfInteger=false] - Include trailing zeros
- * @returns {string} `number` formatted as pound sterling
- */
-function sterling (number, trailingZeroIfInteger = false) {
-  number = normalize(number, '')
-
-  let sterling = new Intl.NumberFormat('en-GB', {
-    style: 'currency',
-    currency: 'GBP'
-  }).format(number)
-
-  /**
-   * TODO: Use options.trailingZeroDisplay once this package requires Node v20
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#trailingzerodisplay}
-   */
-  if (!trailingZeroIfInteger) {
-    sterling = sterling.replace(/\.00$/, '')
-  }
-
-  return sterling
-}
-
 module.exports = {
+  currency,
   isNumber,
-  ordinal,
-  sterling
+  ordinal
 }
 
 // Add number filters to GOV.UK Prototype Kit
+views.addFilter('currency', currency)
 views.addFilter('isNumber', isNumber)
 views.addFilter('ordinal', ordinal)
-views.addFilter('sterling', sterling)

--- a/tests/number.mjs
+++ b/tests/number.mjs
@@ -1,9 +1,24 @@
 import test from 'ava'
 import {
+  currency,
   isNumber,
-  ordinal,
-  sterling
+  ordinal
 } from '../lib/number.js'
+
+test('Converts a number into a string formatted as currency', t => {
+  t.is(currency(81932), '£81,932.00')
+  t.is(currency(133.66667), '£133.67')
+  t.is(currency(75.5), '£75.50')
+  t.is(currency(75, { unit: 'USD' }), 'US$75.00')
+  t.is(currency(75, { display: 'symbol', unit: 'USD' }), 'US$75.00')
+  t.is(currency(75, { display: 'code', unit: 'USD' }), 'USD\u00A075.00')
+  t.is(currency(75.0015, { trailingZeros: false }), '£75')
+  t.is(currency(75, {
+    display: 'name',
+    trailingZeros: false,
+    unit: 'USD',
+  }), '75.00 US dollars')
+})
 
 test('Checks if a value is classified as a `Number` primitive or object', t => {
   t.true(isNumber(1801))
@@ -13,12 +28,4 @@ test('Checks if a value is classified as a `Number` primitive or object', t => {
 test('Converts a number into an ordinal numeral', t => {
   t.is(ordinal(4), 'fourth')
   t.is(ordinal(22), '22nd')
-})
-
-test('Converts a number into a string formatted as pound sterling', t => {
-  t.is(sterling(81932), '£81,932')
-  t.is(sterling(133.66667), '£133.67')
-  t.is(sterling(75.50), '£75.50')
-  t.is(sterling(75.00), '£75')
-  t.is(sterling(75.00, true), '£75.00')
 })


### PR DESCRIPTION
There are use cases within government where [the style guide for displaying money](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money) shouldn’t be followed:

* a service uses another currency besides pounds sterling
* a service uses multiple currencies
* a service compares values in table column (meaning decimals should always be shown)

This PR does a few things:

1. Renames `sterling` to `money`. This filter follows the GOV.UK style for money (although not the guidance around display values in the millions). Trailing zeros are not shown for round numbers, and it takes no options to change the formatting.

2. Adds a new `currency` filter. This provides options for:
  * Unit of currency
  * Formatting of currency
  * Inclusion of leading zeros for round numbers (shown by default)

* * *

In most cases, you would use `currency` in data tables and `money` in running text:

```njk
You owe {{ total | money }}. This is the calculation:

Item     | Value
---------|------
Parsnips | {{ purchases[0] | currency }}
Peanuts  | {{ purchases[1] | currency }}
Potatoes | {{ purchases[2] | currency }}
---------|------
TOTAL    | {{ total | currency }}
```

```html
You owe £7. This is the calculation:

Item     | Value
---------|------
Parsnips | £2.51
Peanuts  | £3.00
Potatoes | £1.49
---------|------
TOTAL    | £7.00
```

* * *

In [the use case highlighted on x-gov Slack](https://ukgovernmentdigital.slack.com/archives/C0647LW4R/p1683793922566359), the following would be used:

```njk
{% set value = (data['facility-1new-paid'] | float) + (data['facility-5new-paid'] | float) %}
{{ value | currency({ format: "code" }) }}
```

```html
GBP £20.00
```

* * *

Is it odd to have 2 similar filters, a simple/opinionated one and one that provides options?

The other option would be to have a single filter, with the defaults set to follow the GOV.UK style for money, but that would necessitate setting an option for leading zeros in some cases – maybe that’s fine? In the above case you would instead use:

```njk
{{ value | currency({ format: "code", trailingZeroIfInteger: true }) }}
```