### PR TITLE
Use keyword arguments for `govukMarkdown` filter

### DIFF
--- a/docs/string.md
+++ b/docs/string.md
@@ -19,7 +19,9 @@ Output
 <p class="govuk-body">Visit <a class="govuk-link" href="https://www.gov.uk">GOV.UK</a>.</p>
 ```
 
-### Heading sizes
+### Options
+
+#### `headingsStartWith`
 
 By default, headings start using the class `govuk-heading-xl`.
 
@@ -45,12 +47,12 @@ Output
 <h4 class="govuk-heading-s">Heading level 4</h4>
 ```
 
-The [GOV.UK Design System recommends changing this](https://design-system.service.gov.uk/styles/typography/#headings) if a page feels unbalanced (heading classes don’t always need to correspond to the heading level). You can start headings using the smaller size by setting the `headingsStartWith` option.
+The [GOV.UK Design System recommends](https://design-system.service.gov.uk/styles/typography/#headings) changing this if a page feels unbalanced (heading classes don’t always need to correspond to the heading level). You can start headings using the smaller size by setting the `headingsStartWith` option.
 
 Input
 
 ```njk
-{{ headings | govukMarkdown({ headingsStartWith: "l" }) | safe }}
+{{ headings | govukMarkdown(headingsStartWith="l") | safe }}
 ```
 
 Output
@@ -60,6 +62,24 @@ Output
 <h2 class="govuk-heading-m">Heading level 2</h2>
 <h3 class="govuk-heading-s">Heading level 3</h3>
 <h4 class="govuk-heading-s">Heading level 4</h4>
+```
+
+#### `smartypants`
+
+Use the `smartypants` option to replace plain ASCII punctuation characters with smart typographic punctuation. Default is `true`.
+
+Input
+
+```njk
+{{ "Don't -- why not?" | govukMarkdown | safe }}
+{{ "Don't -- why not?" | govukMarkdown(smartypants=false) | safe }}
+```
+
+Output
+
+```html
+<p class="govuk-body">Don’t – why not?</h1>
+<p class="govuk-body">Don't -- why not?</h1>
 ```
 
 ## isString

--- a/lib/string.js
+++ b/lib/string.js
@@ -14,19 +14,19 @@ const { normalize } = require('./utils.js')
  * govukMarkdown('Visit [GOV.UK](https://gov.uk).') // <p class="govuk-body">Visit <a class="govuk-link" href="https://www.gov.uk">GOVUK</a>.</p>
  *
  * @param {string} string - Value to convert
- * @param {object} options - Markdown options
+ * @param {object} [kwargs] - Keyword arguments
  * @returns {string} `string` rendered as HTML
  */
-function govukMarkdown (string, options) {
+function govukMarkdown (string, kwargs) {
   string = normalize(string, '')
 
-  const defaults = {
+  const options = {
     headingsStartWith: 'xl',
-    smartypants: true
+    smartypants: true,
+    ...kwargs
   }
 
   marked.setOptions({
-    ...defaults,
     ...options,
     renderer: new GovukHTMLRenderer()
   })

--- a/tests/string.mjs
+++ b/tests/string.mjs
@@ -9,7 +9,18 @@ import {
 } from '../lib/string.js'
 
 test('Converts a Markdown formatted string to HTML', t => {
-  t.is(govukMarkdown('**this** is _emphasis_'), '<p class="govuk-body"><strong>this</strong> is <em>emphasis</em></p>\n')
+  t.is(
+    govukMarkdown("# *Don't*"),
+    '<h1 class="govuk-heading-xl" id="dont"><em>Don’t</em></h1>'
+  )
+  t.is(govukMarkdown(
+    "# *Don't*", { smartypants: false }),
+    '<h1 class="govuk-heading-xl" id="don39t"><em>Don&#39;t</em></h1>'
+  )
+  t.is(
+    govukMarkdown("# *Don't*", { headingsStartWith: 'l' }),
+    '<h1 class="govuk-heading-l" id="dont"><em>Don’t</em></h1>'
+  )
 })
 
 test('Check if a value is classified as a `String`', t => {


### PR DESCRIPTION
Based on the discussion in #14, moves `govukMarkdown` filter to use keyword arguments.

### Before

```njk
{{ content | govukMarkdown({headingsStartWith: "l", smartypants: false}) }}
```

### After

```njk
{{ content | govukMarkdown(headingsStartWith="l", smartypants=false) }}
```

Also adds missing tests for these options, and adds documentation for the `smartypants` option.