### PR TITLE
Refactor `pluralise` filter

### DIFF
--- a/docs/number.md
+++ b/docs/number.md
@@ -123,3 +123,27 @@ Output
 fourth
 22nd
 ```
+
+## pluralise
+
+Get the plural form for an item for a given number of items.
+
+> This filter currently only works with English words.
+
+```njk
+{{ 1 | pluralise("mouse") }}
+{{ 2 | pluralise("house") }}
+{{ 2 | pluralise("house", { number: false }) }}
+{{ 2 | pluralise("mouse", { plural: "mice" }) }}
+{{ 2 | pluralise("mouse", { plural: "mice", number: false }) }}
+```
+
+Output
+
+```html
+1 mouse
+2 houses
+houses
+2 mice
+mice
+```

--- a/docs/number.md
+++ b/docs/number.md
@@ -124,26 +124,40 @@ fourth
 22nd
 ```
 
-## pluralise
+## plural
 
-Get the plural form for an item for a given number of items.
+Get the plural word form for an item for a given number.
 
 > This filter currently only works with English words.
 
 ```njk
-{{ 1 | pluralise("mouse") }}
-{{ 2 | pluralise("house") }}
-{{ 2 | pluralise("house", { number: false }) }}
-{{ 2 | pluralise("mouse", { plural: "mice" }) }}
-{{ 2 | pluralise("mouse", { plural: "mice", number: false }) }}
+{{ 1 | plural("mouse") }}
+{{ 2 | plural("mouse") }}
 ```
 
 Output
 
 ```html
 1 mouse
-2 houses
-houses
 2 mice
+```
+
+### Options
+
+#### `showNumber`
+
+Use the `showNumber` option to show number alongside the pluralised word. Default is `true`.
+
+Input
+
+```njk
+{{ 1 | plural("mouse", showNumber=false) }}
+{{ 2 | plural("mouse", showNumber=false) }}
+```
+
+Output
+
+```html
+mouse
 mice
 ```

--- a/docs/string.md
+++ b/docs/string.md
@@ -98,30 +98,6 @@ Output
 Department for Business, Energy & Industrial&amp;nbsp;Strategy
 ```
 
-## pluralise
-
-Get the plural form for an item for a given number of items.
-
-> This filter currently only works with English words.
-
-```njk
-{{ 1 | pluralise("mouse") }}
-{{ 2 | pluralise("house") }}
-{{ 2 | pluralise("house", { number: false }) }}
-{{ 2 | pluralise("mouse", { plural: "mice" }) }}
-{{ 2 | pluralise("mouse", { plural: "mice", number: false }) }}
-```
-
-Output
-
-```html
-1 mouse
-2 houses
-houses
-2 mice
-mice
-```
-
 ## slugify
 
 Convert a string to kebab-case. This can be useful to slugify titles for use in URLs or fragment identifiers.

--- a/lib/number.js
+++ b/lib/number.js
@@ -1,5 +1,6 @@
 const { views } = require('govuk-prototype-kit')
 const _ = require('lodash')
+const pluralize = require('pluralize')
 const { normalize } = require('./utils.js')
 
 /**
@@ -116,37 +117,37 @@ function ordinal (number) {
  * Get the plural form for an item for a given number of items.
  * Works for English words only.
  *
- * @see {@link http://blog.gnclmorais.com/simple-pluralise-in-javascript}
- *
  * @example
- * pluralise(1, 'mouse') // 1 mouse
- * pluralise(2, 'house') // 2 houses
- * pluralise(2, 'house', { number: false }) // houses
- * pluralise(2, 'mouse', { plural: 'mice' }) // 2 mice
- * pluralise(2, 'mouse', { plural: 'mice', number: false }) // mice
+ * plural(1, 'mouse') // 1 mouse
+ * plural(2, 'mouse') // 2 mice
+ * plural(2, 'mouse', { showNumber: false }) // mice
  *
- * @param {number} count - Number of items
+ * @param {number} number - Number of items
  * @param {string} singular - Singular form
- * @param {object} [options={}] - Options
- * @param {string} [options.plural] - Plural form
- * @param {boolean} [options.number] - Output number alongside word
- * @returns {string} Plural form for `count`
+ * @param {object} [kwargs] - Keyword arguments
+ * @param {boolean} [kwargs.showNumber] - Show number alongside word
+ * @returns {string} Plural word form for `number`
  */
-function pluralise (count, singular, { plural, number } = {}) {
-  const message = count === 1 ? singular : (plural || `${singular}s`)
+function plural (number, singular, kwargs) {
+  number = normalize(number, '')
 
-  return number === false ? message : `${count} ${message}`
+  const options = {
+    showNumber: true,
+    ...kwargs
+  }
+
+  return pluralize(singular, number, options.showNumber)
 }
 
 module.exports = {
   currency,
   isNumber,
   ordinal,
-  pluralise
+  plural
 }
 
 // Add number filters to GOV.UK Prototype Kit
 views.addFilter('currency', currency)
 views.addFilter('isNumber', isNumber)
 views.addFilter('ordinal', ordinal)
-views.addFilter('pluralise', pluralise)
+views.addFilter('plural', plural)

--- a/lib/number.js
+++ b/lib/number.js
@@ -112,13 +112,41 @@ function ordinal (number) {
   return `${number}${suffix}`
 }
 
+/**
+ * Get the plural form for an item for a given number of items.
+ * Works for English words only.
+ *
+ * @see {@link http://blog.gnclmorais.com/simple-pluralise-in-javascript}
+ *
+ * @example
+ * pluralise(1, 'mouse') // 1 mouse
+ * pluralise(2, 'house') // 2 houses
+ * pluralise(2, 'house', { number: false }) // houses
+ * pluralise(2, 'mouse', { plural: 'mice' }) // 2 mice
+ * pluralise(2, 'mouse', { plural: 'mice', number: false }) // mice
+ *
+ * @param {number} count - Number of items
+ * @param {string} singular - Singular form
+ * @param {object} [options={}] - Options
+ * @param {string} [options.plural] - Plural form
+ * @param {boolean} [options.number] - Output number alongside word
+ * @returns {string} Plural form for `count`
+ */
+function pluralise (count, singular, { plural, number } = {}) {
+  const message = count === 1 ? singular : (plural || `${singular}s`)
+
+  return number === false ? message : `${count} ${message}`
+}
+
 module.exports = {
   currency,
   isNumber,
-  ordinal
+  ordinal,
+  pluralise
 }
 
 // Add number filters to GOV.UK Prototype Kit
 views.addFilter('currency', currency)
 views.addFilter('isNumber', isNumber)
 views.addFilter('ordinal', ordinal)
+views.addFilter('pluralise', pluralise)

--- a/lib/string.js
+++ b/lib/string.js
@@ -58,32 +58,6 @@ function isString (value) {
 }
 
 /**
- * Get the plural form for an item for a given number of items.
- * Works for English words only.
- *
- * @see {@link http://blog.gnclmorais.com/simple-pluralise-in-javascript}
- *
- * @example
- * pluralise(1, 'mouse') // 1 mouse
- * pluralise(2, 'house') // 2 houses
- * pluralise(2, 'house', { number: false }) // houses
- * pluralise(2, 'mouse', { plural: 'mice' }) // 2 mice
- * pluralise(2, 'mouse', { plural: 'mice', number: false }) // mice
- *
- * @param {number} count - Number of items
- * @param {string} singular - Singular form
- * @param {object} [options={}] - Options
- * @param {string} [options.plural] - Plural form
- * @param {boolean} [options.number] - Output number alongside word
- * @returns {string} Plural form for `count`
- */
-function pluralise (count, singular, { plural, number } = {}) {
-  const message = count === 1 ? singular : (plural || `${singular}s`)
-
-  return number === false ? message : `${count} ${message}`
-}
-
-/**
  * Insert a non-breaking space between the last two words of a string. This
  * prevents an orphaned word appearing by itself at the end of a paragraph.
  *
@@ -143,7 +117,6 @@ module.exports = {
   govukMarkdown,
   isString,
   noOrphans,
-  pluralise,
   slugify,
   startsWith
 }
@@ -152,6 +125,5 @@ module.exports = {
 views.addFilter('govukMarkdown', govukMarkdown)
 views.addFilter('isString', isString)
 views.addFilter('noOrphans', noOrphans)
-views.addFilter('pluralise', pluralise)
 views.addFilter('slugify', slugify)
 views.addFilter('startsWith', startsWith)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "lodash": "^4.17.21",
         "luxon": "^3.2.1",
         "marked": "^5.0.0",
-        "marked-smartypants": "^1.0.0"
+        "marked-smartypants": "^1.0.0",
+        "pluralize": "^8.0.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -7046,6 +7047,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/portscanner": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lodash": "^4.17.21",
     "luxon": "^3.2.1",
     "marked": "^5.0.0",
-    "marked-smartypants": "^1.0.0"
+    "marked-smartypants": "^1.0.0",
+    "pluralize": "^8.0.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0",

--- a/tests/number.mjs
+++ b/tests/number.mjs
@@ -3,7 +3,7 @@ import {
   currency,
   isNumber,
   ordinal,
-  pluralise
+  plural
 } from '../lib/number.js'
 
 test('Converts a number into a string formatted as currency', t => {
@@ -31,10 +31,8 @@ test('Converts a number into an ordinal numeral', t => {
   t.is(ordinal(22), '22nd')
 })
 
-test('Gets the plural form for an item for a given number of items', t => {
-  t.is(pluralise(1, 'mouse'), '1 mouse')
-  t.is(pluralise(2, 'house'), '2 houses')
-  t.is(pluralise(2, 'house', { number: false }), 'houses')
-  t.is(pluralise(2, 'mouse', { plural: 'mice' }), '2 mice')
-  t.is(pluralise(2, 'mouse', { plural: 'mice', number: false }), 'mice')
+test('Gets the plural word form for an item for a given number', t => {
+  t.is(plural(1, 'mouse'), '1 mouse')
+  t.is(plural(2, 'mouse'), '2 mice')
+  t.is(plural(2, 'mouse', { showNumber: false }), 'mice')
 })

--- a/tests/number.mjs
+++ b/tests/number.mjs
@@ -2,7 +2,8 @@ import test from 'ava'
 import {
   currency,
   isNumber,
-  ordinal
+  ordinal,
+  pluralise
 } from '../lib/number.js'
 
 test('Converts a number into a string formatted as currency', t => {
@@ -28,4 +29,12 @@ test('Checks if a value is classified as a `Number` primitive or object', t => {
 test('Converts a number into an ordinal numeral', t => {
   t.is(ordinal(4), 'fourth')
   t.is(ordinal(22), '22nd')
+})
+
+test('Gets the plural form for an item for a given number of items', t => {
+  t.is(pluralise(1, 'mouse'), '1 mouse')
+  t.is(pluralise(2, 'house'), '2 houses')
+  t.is(pluralise(2, 'house', { number: false }), 'houses')
+  t.is(pluralise(2, 'mouse', { plural: 'mice' }), '2 mice')
+  t.is(pluralise(2, 'mouse', { plural: 'mice', number: false }), 'mice')
 })

--- a/tests/string.mjs
+++ b/tests/string.mjs
@@ -3,7 +3,6 @@ import {
   govukMarkdown,
   isString,
   noOrphans,
-  pluralise,
   slugify,
   startsWith
 } from '../lib/string.js'
@@ -22,14 +21,6 @@ test('Converts a Markdown formatted string to HTML', t => {
 test('Check if a value is classified as a `String`', t => {
   t.true(isString('Number 10'))
   t.false(isString(10))
-})
-
-test('Gets the plural form for an item for a given number of items', t => {
-  t.is(pluralise(1, 'mouse'), '1 mouse')
-  t.is(pluralise(2, 'house'), '2 houses')
-  t.is(pluralise(2, 'house', { number: false }), 'houses')
-  t.is(pluralise(2, 'mouse', { plural: 'mice' }), '2 mice')
-  t.is(pluralise(2, 'mouse', { plural: 'mice', number: false }), 'mice')
 })
 
 test('Inserts non-breaking space between the last two words of a string', t => {


### PR DESCRIPTION
Based on the discussion in #14, updates `pluralise` filter to use keyword arguments.

Also:

* Moves filter to number collection
* Renames filter `plural` (to match `ordinal`)
* Removes `plural` option (by including [pluralize](https://www.npmjs.com/package/pluralize) as a dependency)
* Renames `number` option to `showNumber`
* Updates documentation

## Before

```njk
{{ 2 | pluralise("mouse", { plural: "mice", number: false }) }}  // mice
```

## After

```njk
{{ 2 | plural("mouse", showNumber=false) }}  // mice
```