### PR TITLE
Move package under x-govuk organisation namespace on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Node.js v16 or later.
 ## Installation
 
 ```shell
-npm install govuk-prototype-filters
+npm install @x-govuk/govuk-prototype-filters
 ```
 
 ## Usage with the GOV.UK Prototype Kit
@@ -26,10 +26,10 @@ If you are using v13 or later of the kit, the components will be immediately ava
 
 ## Advanced usage
 
-`govuk-prototype-filters` exports an object containing all available filter functions. Using [Nunjucks’ `addFilter` method](https://mozilla.github.io/nunjucks/api.html#addfilter) you can add individual filters to your Nunjucks environment:
+`@x-govuk/govuk-prototype-filters` exports an object containing all available filter functions. Using [Nunjucks’ `addFilter` method](https://mozilla.github.io/nunjucks/api.html#addfilter) you can add individual filters to your Nunjucks environment:
 
 ```js
-const { slugify } = require('govuk-prototype-filters')
+const { slugify } = require('@x-govuk/govuk-prototype-filters')
 const nunjucks = require('nunjucks')
 
 const nunjucksEnv = nunjucks.configure(['./app/views'])
@@ -40,7 +40,7 @@ nunjucksEnv.addFilter("slugify", slugify)
 If you are using an earlier version of the GOV.UK Prototype Kit, you can import all the filters into your `/app/filters.js` file, like so:
 
 ```diff
-+ const prototypeFilters = require('govuk-prototype-filters');
++ const prototypeFilters = require('@x-govuk/govuk-prototype-filters');
 
   module.exports = function (env) {
     /**

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Node.js v16 or later.
 ## Installation
 
 ```shell
-npm install govuk-prototype-filters
+npm install @x-govuk/govuk-prototype-filters
 ```
 
 GOV.UK Prototype Filters are designed to work with the GOV.UK Prototype Kit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "govuk-prototype-filters",
+  "name": "@x-govuk/govuk-prototype-filters",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "govuk-prototype-filters",
+      "name": "@x-govuk/govuk-prototype-filters",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk-prototype-filters",
+  "name": "@x-govuk/govuk-prototype-filters",
   "version": "0.1.0",
   "description": "Nunjucks filters for use with the GOV.UK Prototype Kit",
   "keywords": [


### PR DESCRIPTION
To make it clearer that this is not a GDS-owned or endorsed project, this PR readies the package for being moved under the `@x-govuk` organisation on NPM, and updates associated documentation.

When version 1.0.0 of this package is published, this new namespace will used.

Fixes #3.