### PR TITLE
Upgrade `marked` dependency to 5.0

### DIFF
--- a/docs/string.md
+++ b/docs/string.md
@@ -64,24 +64,6 @@ Output
 <h4 class="govuk-heading-s">Heading level 4</h4>
 ```
 
-#### `smartypants`
-
-Use the `smartypants` option to replace plain ASCII punctuation characters with smart typographic punctuation. Default is `true`.
-
-Input
-
-```njk
-{{ "Don't -- why not?" | govukMarkdown | safe }}
-{{ "Don't -- why not?" | govukMarkdown(smartypants=false) | safe }}
-```
-
-Output
-
-```html
-<p class="govuk-body">Don’t – why not?</h1>
-<p class="govuk-body">Don't -- why not?</h1>
-```
-
 ## isString
 
 Checks if a value is classified as a [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) primitive or object.

--- a/lib/string.js
+++ b/lib/string.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const GovukHTMLRenderer = require('govuk-markdown')
 const { views } = require('govuk-prototype-kit')
 const { marked } = require('marked')
+const { markedSmartypants } = require('marked-smartypants')
 const { normalize } = require('./utils.js')
 
 /**
@@ -22,14 +23,18 @@ function govukMarkdown (string, kwargs) {
 
   const options = {
     headingsStartWith: 'xl',
-    smartypants: true,
     ...kwargs
   }
 
   marked.setOptions({
     ...options,
+    headerIds: false, // Quieten deprecation warning in marked.js 5.x
+    mangle: false, // Quieten deprecation warning in marked.js 5.x
     renderer: new GovukHTMLRenderer()
   })
+
+  // @ts-ignore
+  marked.use(markedSmartypants())
 
   return marked(string)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "govuk-markdown": "^0.3.0",
+        "govuk-markdown": "^0.4.0",
         "lodash": "^4.17.21",
         "luxon": "^3.2.1",
-        "marked": "^4.2.12"
+        "marked": "^5.0.0",
+        "marked-smartypants": "^1.0.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -4160,15 +4161,15 @@
       }
     },
     "node_modules/govuk-markdown": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-markdown/-/govuk-markdown-0.3.0.tgz",
-      "integrity": "sha512-KjNcso/TmxrDqkYTwdWlGSWKYI31ojXYUJfBfNopsTFw6MewTFQsrg+OB6h7RJBIdzvYiWCmgKrewppTG4QSHg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-markdown/-/govuk-markdown-0.4.0.tgz",
+      "integrity": "sha512-DSEZ02kRVeAbOvNBUubEfPZxMRIjLfc26gfOcarDX7GXz6Ij9lBddhBOBylJ0IQaNGTQANgj8GF6radrYN66nQ==",
       "dependencies": {
         "highlight.js": "^11.5.0",
-        "marked": "^4.0.12"
+        "marked": "^5.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/govuk-prototype-kit": {
@@ -4310,6 +4311,17 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/govuk-prototype-kit/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/govuk-prototype-kit/node_modules/p-map": {
@@ -5974,14 +5986,25 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.2.tgz",
+      "integrity": "sha512-TXksm9GwqXCRNbFUZmMtqNLvy3K2cQHuWmyBDLOrY1e6i9UvZpOTJXoz7fBjYkJkaUFzV9hBFxMuZSyQt8R6KQ==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-smartypants": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/marked-smartypants/-/marked-smartypants-1.0.2.tgz",
+      "integrity": "sha512-hpbM9waiBSIHpqdoU5AAeuYozeObBwUet3xkCFrFBA+1329byRVxLDwYmelMCS3ss+sEVJhDgrunIy+ubiqFwQ==",
+      "dependencies": {
+        "smartypants": "^0.1.6"
+      },
+      "peerDependencies": {
+        "marked": "^4 || ^5"
       }
     },
     "node_modules/matcher": {
@@ -8198,7 +8221,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.6.tgz",
       "integrity": "sha512-zGXh+Q6Y3OPTLM5x2HxAIkEAj4ZcePftmIOdIYozv2T+m03Sp5R4YppczKuo6IdnSMc99U+Wgvy8Mil0eeep7g==",
-      "dev": true,
       "bin": {
         "smartypants": "bin/smartypants.js",
         "smartypantsu": "bin/smartypantsu.js"

--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
     "access": "public"
   },
   "dependencies": {
-    "govuk-markdown": "^0.3.0",
+    "govuk-markdown": "^0.4.0",
     "lodash": "^4.17.21",
     "luxon": "^3.2.1",
-    "marked": "^4.2.12"
+    "marked": "^5.0.0",
+    "marked-smartypants": "^1.0.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0",

--- a/tests/string.mjs
+++ b/tests/string.mjs
@@ -10,16 +10,12 @@ import {
 
 test('Converts a Markdown formatted string to HTML', t => {
   t.is(
-    govukMarkdown("# *Don't*"),
-    '<h1 class="govuk-heading-xl" id="dont"><em>Don’t</em></h1>'
-  )
-  t.is(govukMarkdown(
-    "# *Don't*", { smartypants: false }),
-    '<h1 class="govuk-heading-xl" id="don39t"><em>Don&#39;t</em></h1>'
+    govukMarkdown(`He said, -- "A 'simple' sentence..." --- unknown`),
+    '<p class="govuk-body">He said, &#8211; &#8220;A &#8216;simple&#8217; sentence&#8230;&#8221; &#8212; unknown</p>\n'
   )
   t.is(
-    govukMarkdown("# *Don't*", { headingsStartWith: 'l' }),
-    '<h1 class="govuk-heading-l" id="dont"><em>Don’t</em></h1>'
+    govukMarkdown("# Large heading", { headingsStartWith: 'l' }),
+    '<h1 class="govuk-heading-l" id="large-heading">Large heading</h1>'
   )
 })
 


### PR DESCRIPTION
[Marked.js 5.0 has deprecated a number of its options and moved them to plugins](https://github.com/markedjs/marked/releases/tag/v5.0.0).

Annoyingly, this means either setting an option to `false` to prevent a deprecation warning, or including a new plugin dependency to enable the option. Further still, by enabling `smartypants` option using the new plugin, I’m seemingly unable to then disable it.

Anyway, that annoyance convinced me to remove smartypants as option and enable it by default. Good idea?