### PR TITLE
Add plugin metadata

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,4 +1,12 @@
 {
+  "meta": {
+    "description": "Use this GOV.UK Prototype Kit plugin to add helpful filters to Nunjucks templates. Rapidly modify and transform data while ensuring it follows the GOV.UK style guide.",
+    "urls": {
+      "documentation": "https://x-govuk.github.io/govuk-prototype-filters",
+      "releaseNotes": "https://github.com/x-govuk/govuk-prototype-filters/releases/tag/v{{version}}",
+      "versionHistory": "https://github.com/x-govuk/govuk-prototype-filters/releases"
+    }
+  },
   "nunjucksFilters": [
     "/lib/array.js",
     "/lib/date.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "eleventy --quiet",
     "start": "eleventy --serve --quiet",
     "lint": "eslint '**/*.js'",
-    "test": "ava",
+    "test": "ava && npx govuk-prototype-kit@latest validate-plugin",
     "coverage": "c8 ava"
   },
   "publishConfig": {


### PR DESCRIPTION
We're working on a new plugin page, we'll be making use of new metadata that comes from plugin config.  This PR adds that metadata.

I've also added the validator to the tests, this uses `npx` and `@latest` to always look at the latest requirements.  I recommend this approach but it does erode the purity of repeatable builds, you could hardcode a version number in there or install `govuk-prototype-kit` as a (dev) dependency and remove both `npx` and `@latest`.