### PR TITLE
Use `renderAsHtml` option

### DIFF
--- a/docs/string.md
+++ b/docs/string.md
@@ -13,7 +13,7 @@ Convert a Markdown formatted string into HTML decorated with [typography classes
 **Input**
 
 ```njk
-{{ "Visit [GOV.UK](https://gov.uk)." | govukMarkdown | safe }}
+{{ "Visit [GOV.UK](https://gov.uk)." | govukMarkdown }}
 ```
 
 **Output**
@@ -36,7 +36,7 @@ By default, headings start using the class `govuk-heading-xl`.
 #### Heading level 4
 {% endset %}
 
-{{ headings | govukMarkdown | safe }}
+{{ headings | govukMarkdown }}
 ```
 
 **Output**
@@ -55,7 +55,7 @@ Start headings using the smaller size by setting the `headingsStartWith` option:
 **Input**
 
 ```njk
-{{ headings | govukMarkdown(headingsStartWith="l") | safe }}
+{{ headings | govukMarkdown(headingsStartWith="l") }}
 ```
 
 **Output**

--- a/docs/string.md
+++ b/docs/string.md
@@ -98,7 +98,7 @@ This prevents an orphaned word appearing by itself at the end of a paragraph. Th
 **Input**
 
 ```njk
-{{ "Department for Business, Energy & Industrial Strategy" | noOrphans | safe }}
+{{ "Department for Business, Energy & Industrial Strategy" | noOrphans }}
 ```
 
 **Output**

--- a/lib/string.js
+++ b/lib/string.js
@@ -122,6 +122,6 @@ module.exports = {
 // Add object filters to GOV.UK Prototype Kit
 views.addFilter('govukMarkdown', govukMarkdown, { renderAsHtml: true })
 views.addFilter('isString', isString)
-views.addFilter('noOrphans', noOrphans)
+views.addFilter('noOrphans', noOrphans, { renderAsHtml: true })
 views.addFilter('slugify', slugify)
 views.addFilter('startsWith', startsWith)

--- a/lib/string.js
+++ b/lib/string.js
@@ -120,7 +120,7 @@ module.exports = {
 }
 
 // Add object filters to GOV.UK Prototype Kit
-views.addFilter('govukMarkdown', govukMarkdown)
+views.addFilter('govukMarkdown', govukMarkdown, { renderAsHtml: true })
 views.addFilter('isString', isString)
 views.addFilter('noOrphans', noOrphans)
 views.addFilter('slugify', slugify)


### PR DESCRIPTION
Uses `renderAsHtml` option for `govukMarkdown` and `noOrphans` filters. This means output doesn’t need to use the `safe` filter to prevent HTML from being escaped.

Fixes #25.