### PR TITLE
Update time filter so that midnight and midday include the time

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -178,7 +178,7 @@ function govukTime (string) {
     // Show the hour followed by meridiem indicator (no space)
     let time = `${hour}${meridiem}`
 
-    // If the time is 12:00am, show ‘midnight’ instead
+    // If the time is 12am, show ‘midnight’ in brackets
     if (time === '12am') {
       time = '12am (midnight)'
     }

--- a/lib/date.js
+++ b/lib/date.js
@@ -183,7 +183,7 @@ function govukTime (string) {
       time = '12am (midnight)'
     }
 
-    // If the time is 12:00pm, show ‘midday’ instead
+    // If the time is 12pm, show ‘midday’ in brackets
     if (time === '12pm') {
       time = '12pm (midday)'
     }

--- a/lib/date.js
+++ b/lib/date.js
@@ -180,12 +180,12 @@ function govukTime (string) {
 
     // If the time is 12:00am, show ‘midnight’ instead
     if (time === '12am') {
-      time = 'midnight'
+      time = '12am (midnight)'
     }
 
     // If the time is 12:00pm, show ‘midday’ instead
     if (time === '12pm') {
-      time = 'midday'
+      time = '12pm (midday)'
     }
 
     return time

--- a/tests/date.mjs
+++ b/tests/date.mjs
@@ -60,8 +60,8 @@ test('Returns error converting an ISO 8601 date time to a date using the GOV.UK 
 
 test('Converts an ISO 8601 date time to a time using the GOV.UK style', t => {
   t.is(govukTime('2021-08-17T18:30:00'), '6:30pm')
-  t.is(govukTime('2021-08-17T00:00:59'), 'midnight')
-  t.is(govukTime('2021-08-17T12:00:59'), 'midday')
+  t.is(govukTime('2021-08-17T00:00:59'), '12am (midnight)')
+  t.is(govukTime('2021-08-17T12:00:59'), '12pm (midday)')
   t.is(govukTime('18:30'), '6:30pm')
   t.truthy(govukTime('now'))
 })


### PR DESCRIPTION
For the last few years whenever we’ve had to render out a time, we would always include the time 12pm or 12am but clarify it's meaning in brackets.

So the sentence would read:

`The application was rejected on 22 September 2023 at 12pm (midday).`

I was hoping the filter could be updated so that:

- `midnight` becomes `12am (midnight)`
- `midday` becomes `12pm (midday)`
