### PR TITLE
Add `govukDateTime` filter

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -112,12 +112,12 @@ To return a date from today’s date, pass the special word `"today"` (or `"now"
 
 ## govukDate
 
-Convert an ISO 8601 date time into a human readable date that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates).
+Convert an ISO 8601 date string into a human readable date that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates).
 
 **Input**
 
 ```njk
-{{ "2021-08-17" | govukDate }}
+{{ "2021-08-17T18:30:00" | govukDate }}
 ```
 
 **Output**
@@ -125,6 +125,8 @@ Convert an ISO 8601 date time into a human readable date that follows [the GOV.U
 ```html
 17 August 2021
 ```
+
+> This filter only outputs a date. If you want to output the date and time from an ISO 8601 date string, use [`govukDateTime`](#govukdatetime).
 
 You can also output a date with a truncated month:
 
@@ -151,14 +153,14 @@ This page was last updated on {{ "today" | govukDate }}.
 **Output**
 
 ```html
-This page was last updated on 22 October 2021.
+This page was last updated on 21 October 2021.
 ```
 
 ---
 
 ## govukTime
 
-Format an ISO 8601 date time or time to a human readable time that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times).
+Format an ISO 8601 date string or time to a human readable time that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times).
 
 **Input**
 
@@ -201,7 +203,81 @@ You submitted your application at {{ "now" | govukTime }}.
 **Output**
 
 ```html
-You submitted your application at 4:32pm.
+You submitted your application at 10:45am.
+```
+
+---
+
+## govukDateTime
+
+Convert an ISO 8601 date string into a human readable date and time that follows the GOV.UK style.
+
+**Input**
+
+```njk
+{{ "2021-08-17T18:30:00" | govukDateTime }}
+```
+
+**Output**
+
+```html
+17 August 2021 at 6:30pm
+```
+
+You can also output the time before the date:
+
+**Input**
+
+```njk
+{{ "2021-08-17T18:30:00" | govukDateTime("on") }}
+```
+
+**Output**
+
+```html
+6:30pm on 17 August 2021
+```
+
+To get the current date and time, pass the special word `"now"` (or `"today"`):
+
+**Input**
+
+```njk
+This page was last updated on {{ "now" | govukDateTime }}.
+```
+
+**Output**
+
+```html
+This page was last updated on 21 October 2021 at 10:45am.
+```
+
+If the date doesn’t include a time, only the date will be output:
+
+**Input**
+
+```njk
+{{ "2021-08-17" | govukDateTime }}
+```
+
+**Output**
+
+```html
+17 August 2021
+```
+
+If only a time is given, only a time will be output:
+
+**Input**
+
+```njk
+{{ "18:30" | govukDateTime }}
+```
+
+**Output**
+
+```html
+6:30pm
 ```
 
 ---

--- a/lib/date.js
+++ b/lib/date.js
@@ -71,7 +71,8 @@ function duration(string, number, unit) {
 }
 
 /**
- * Convert ISO 8601 date time into a human readable date with the GOV.UK style.
+ * Convert ISO 8601 date string into a human readable date
+ * with the GOV.UK style.
  * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates}
  * @example <caption>Full date</caption>
  * govukDate('2021-08-17') // 17 August 2021
@@ -118,8 +119,8 @@ function govukDate(string, format = false) {
 }
 
 /**
- * Format ISO 8601 date time or time to a human readable time with the GOV.UK
- * style.
+ * Format ISO 8601 date string or time to a human readable time
+ * with the GOV.UK style.
  * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times}
  * @example <caption>Full date time</caption>
  * govukTime('2021-08-17T18:30:00') // 6:30pm
@@ -130,7 +131,7 @@ function govukDate(string, format = false) {
  * @example <caption>Time only</caption>
  * govukTime('18:30') // 6:30pm
  * @example <caption>The time now</caption>
- * govukTime('now') // 10:45pm
+ * govukTime('now') // 10:45am
  * @param {string} string - Time
  * @returns {string} `string` as a human readable time
  */
@@ -166,6 +167,40 @@ function govukTime(string) {
     return time
   } catch (error) {
     return error.message.split(':')[0]
+  }
+}
+
+/**
+ * Convert ISO 8601 date string into a human readable date and time
+ * with the GOV.UK style.
+ * @example <caption>Full date and time</caption>
+ * govukDateTime('2021-08-17T18:30:00') // 17 August 2021 at 6:30pm
+ * @example <caption>Full time and date</caption>
+ * govukDateTime('2021-08-17', 'on') // 6:30pm on 17 August 2021
+ * @example <caption>Date only</caption>
+ * govukDateTime('2021-08-17') // 17 August 2021
+ * @example <caption>Time only</caption>
+ * govukDateTime('18:30') // 6:30pm
+ * @example <caption>The date and time now</caption>
+ * govukDateTime('now') // 21 October 2021 at 10:45am
+ * @param {string} string - Date
+ * @param {boolean|string} [format] - Date format (currently accepts ‘on’)
+ * @returns {string} `string` as a human readable date
+ */
+function govukDateTime(string, format = false) {
+  string = normalize(string, '')
+
+  const components = string.split('T')
+
+  if (components.length === 2) {
+    const date = govukDate(components[0], format)
+    const time = govukTime(components[1])
+
+    return format === 'on' ? `${time} on ${date}` : `${date} at ${time}`
+  } else if (string.includes(':')) {
+    return govukTime(string)
+  } else {
+    return govukDate(components[0])
   }
 }
 
@@ -246,6 +281,7 @@ module.exports = {
   daysAgo,
   duration,
   govukDate,
+  govukDateTime,
   govukTime,
   isoDateFromDateInput,
   monthName
@@ -255,6 +291,7 @@ module.exports = {
 views.addFilter('daysAgo', daysAgo)
 views.addFilter('duration', duration)
 views.addFilter('govukDate', govukDate)
+views.addFilter('govukDateTime', govukDateTime)
 views.addFilter('govukTime', govukTime)
 views.addFilter('isoDateFromDateInput', isoDateFromDateInput)
 views.addFilter('monthName', monthName)

--- a/test/date.js
+++ b/test/date.js
@@ -5,6 +5,7 @@ const {
   duration,
   govukDate,
   govukTime,
+  govukDateTime,
   isoDateFromDateInput,
   monthName
 } = require('../lib/date.js')
@@ -89,6 +90,35 @@ describe('Date filters', async () => {
 
   it('Returns error converting an ISO 8601 date time to a time using the GOV.UK style', () => {
     assert.equal(govukTime('2021-08-17T25:61:00'), 'Invalid DateTime')
+  })
+
+  it('Converts ISO 8601 date time to date time with the GOV.UK style', () => {
+    assert.equal(
+      govukDateTime('2021-08-17T18:30:00'),
+      '17 August 2021 at 6:30pm'
+    )
+    assert.equal(
+      govukDateTime('2021-08-17T18:30:00', 'on'),
+      '6:30pm on 17 August 2021'
+    )
+    assert.equal(
+      govukDateTime('2021-08-17T00:00:59'),
+      '17 August 2021 at 12am (midnight)'
+    )
+    assert.equal(
+      govukDateTime('2021-08-17T12:00:59'),
+      '17 August 2021 at 12pm (midday)'
+    )
+    assert.equal(govukDateTime('2021-08-17'), '17 August 2021')
+    assert.equal(govukDateTime('18:30'), '6:30pm')
+    assert.ok(govukDateTime('now'))
+  })
+
+  it('Returns error converting an ISO 8601 date time to date time using the GOV.UK style', () => {
+    assert.equal(
+      govukDateTime('2021-08-17T25:61:00'),
+      '17 August 2021 at Invalid DateTime'
+    )
   })
 
   it('Converts `govukDateInput` values to ISO 8601 date', () => {


### PR DESCRIPTION
Convert an ISO 8601 date string into a human readable date and time that follows the GOV.UK style. Fixes #32.

**Input**

```njk
{{ "2021-08-17T18:30:00" | govukDateTime }}
```

**Output**

```html
17 August 2021 at 6:30pm
```

You can also output the time before the date:

**Input**

```njk
{{ "2021-08-17T18:30:00" | govukDateTime("on") }}
```

**Output**

```html
6:30pm on 17 August 2021
```

To get the current date and time, pass the special word `"now"` (or `"today"`):

**Input**

```njk
This page was last updated on {{ "now" | govukDateTime }}.
```

**Output**

```html
This page was last updated on 21 October 2021 at 10:45am.
```

If the date doesn’t include a time, only the date will be output:

**Input**

```njk
{{ "2021-08-17" | govukDateTime }}
```

**Output**

```html
17 August 2021
```

If only a time is given, only a time will be output:

**Input**

```njk
{{ "18:30" | govukDateTime }}
```

**Output**

```html
6:30pm
```