### PR TITLE
Make includes safe for null values

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -13,6 +13,7 @@ const { normalize } = require('./utils.js')
  * @returns {boolean} Returns true or false
  */
 function arrayOrStringIncludes(array, searchElement) {
+  if (!array || !array.includes) return false
   return array.includes(searchElement)
 }
 


### PR DESCRIPTION
resolves #58 

If the value passed to the `includes` filter is null or does not have the `.includes` method, it returns false, instead of raising an error. I think this is preferred behaviour for prototyping, where people often don't know to check for that before applying a filter (and its better to do it in one place than on every usage)