### PR TITLE
Markdown Filter: only set middleware for marked once to avoid stack overflow

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -17,6 +17,9 @@ const { normalize } = require('./utils.js')
 function govukMarkdown(string, kwargs) {
   string = normalize(string, '')
 
+  // reset mark to default state
+  marked.defaults = {}
+
   marked.use(
     markedGovukMarkdown({
       headingsStartWith: 'xl',

--- a/lib/string.js
+++ b/lib/string.js
@@ -5,6 +5,27 @@ const markedGovukMarkdown = require('govuk-markdown')
 const { markedSmartypants } = require('marked-smartypants')
 const { normalize } = require('./utils.js')
 
+
+let markedInitialized = false;
+let markedOptions = {};
+
+/**
+ * Initializes the marked library with custom options.
+ * 
+ * @param {Object} kwargs - An object containing custom options for marked.
+ * 
+ * Initializes marked with the specified options and plugins (markedGovukMarkdown and markedSmartypants).
+ * This function ensures marked is only initialized once.
+ */
+function initMarked(kwargs) {
+  if (!markedInitialized) {
+    markedOptions = { headingsStartWith: 'xl', ...kwargs };
+    marked.use(markedGovukMarkdown(markedOptions));
+    marked.use(markedSmartypants());
+    markedInitialized = true;
+  }
+}
+
 /**
  * Convert Markdown formatted string into HTML decorated with typography
  * classes from the GOV.UK Design System.
@@ -15,18 +36,11 @@ const { normalize } = require('./utils.js')
  * @returns {string|Promise<string>} `string` rendered as HTML
  */
 function govukMarkdown(string, kwargs) {
-  string = normalize(string, '')
+  initMarked(kwargs);
 
-  marked.use(
-    markedGovukMarkdown({
-      headingsStartWith: 'xl',
-      ...kwargs
-    })
-  )
+  string = normalize(string, '');
 
-  marked.use(markedSmartypants())
-
-  return marked(string)
+  return marked(string);
 }
 
 /**

--- a/lib/string.js
+++ b/lib/string.js
@@ -17,7 +17,7 @@ const { normalize } = require('./utils.js')
 function govukMarkdown(string, kwargs) {
   string = normalize(string, '')
 
-  // reset mark to default state
+  // reset marked to default state
   marked.defaults = {}
 
   marked.use(

--- a/lib/string.js
+++ b/lib/string.js
@@ -5,27 +5,6 @@ const markedGovukMarkdown = require('govuk-markdown')
 const { markedSmartypants } = require('marked-smartypants')
 const { normalize } = require('./utils.js')
 
-
-let markedInitialized = false;
-let markedOptions = {};
-
-/**
- * Initializes the marked library with custom options.
- * 
- * @param {Object} kwargs - An object containing custom options for marked.
- * 
- * Initializes marked with the specified options and plugins (markedGovukMarkdown and markedSmartypants).
- * This function ensures marked is only initialized once.
- */
-function initMarked(kwargs) {
-  if (!markedInitialized) {
-    markedOptions = { headingsStartWith: 'xl', ...kwargs };
-    marked.use(markedGovukMarkdown(markedOptions));
-    marked.use(markedSmartypants());
-    markedInitialized = true;
-  }
-}
-
 /**
  * Convert Markdown formatted string into HTML decorated with typography
  * classes from the GOV.UK Design System.
@@ -36,11 +15,18 @@ function initMarked(kwargs) {
  * @returns {string|Promise<string>} `string` rendered as HTML
  */
 function govukMarkdown(string, kwargs) {
-  initMarked(kwargs);
+  string = normalize(string, '')
 
-  string = normalize(string, '');
+  marked.use(
+    markedGovukMarkdown({
+      headingsStartWith: 'xl',
+      ...kwargs
+    })
+  )
 
-  return marked(string);
+  marked.use(markedSmartypants())
+
+  return marked(string)
 }
 
 /**


### PR DESCRIPTION
previously each time the filter is called it adds additional middleware. eventually causing a stack overflow. 

This PR ensures that that is only done once