### PR TITLE
Truncate September to ‘Sep’, not ‘Sept’

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -2,6 +2,7 @@ const { views } = require('govuk-prototype-kit')
 const { DateTime, Duration, Settings } = require('luxon')
 const { normalize } = require('./utils.js')
 
+Settings.defaultLocale = 'en-GB'
 Settings.throwOnInvalid = true
 
 /**
@@ -105,14 +106,22 @@ function govukDate(string, format = false) {
     // 2021-08 => August 2021
     // 2021-08 => Aug 2021 (truncated)
     if (dateHasNoDay) {
-      const tokens = truncateDate ? 'MMM yyyy' : 'MMMM yyyy'
-      return date.toFormat(tokens)
+      const tokens = truncateDate ? 'LLL yyyy' : 'LLLL yyyy'
+      let formattedDate = date.toFormat(tokens)
+
+      // Node.js uses four-letter abbreviation for September only, weirdly
+      formattedDate = formattedDate.replace(/Sept\s/, 'Sep ')
+      return formattedDate
     }
 
     // 2021-08-17 => 17 August 2021
     // 2021-08-17 => 17 Aug 2021 (truncated)
     const preset = truncateDate ? 'DATE_MED' : 'DATE_FULL'
-    return date.setLocale('en-GB').toLocaleString(DateTime[preset])
+    let formattedDate = date.toLocaleString(DateTime[preset])
+
+    // Node.js uses four-letter abbreviation for September only, weirdly
+    formattedDate = formattedDate.replace(/Sept\s/, 'Sep ')
+    return formattedDate
   } catch (error) {
     return error.message.split(':')[0]
   }

--- a/test/date.js
+++ b/test/date.js
@@ -76,6 +76,11 @@ describe('Date filters', async () => {
     )
   })
 
+  it('Truncates September to 3 letters', () => {
+    assert.equal(govukDate('2024-09-21', 'truncate'), '21 Sep 2024')
+    assert.equal(govukDate('2024-09', 'truncate'), 'Sep 2024')
+  })
+
   it('Returns error converting ISO 8601 date to date with GOV.UK style', () => {
     assert.equal(govukDate('2021-23-45'), 'Invalid DateTime')
   })


### PR DESCRIPTION
~~Browsers trancate~~ __Safari truncates__ all months to three letters in `short` mode, but ~~Node.js~~ __most other runtimes__ uses four for September only, which is a bit weird.

Without being able to dig into the weeds of Node.js, or compile different versions of it with different ICU settings, let’s just special case it. 😢

Fixes #87.