### PR TITLE
Ensure `monthName` filter abbreviates ‘September’ to ‘Sep‘

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -324,9 +324,13 @@ function monthName(number, format = false) {
   const date = new Date(2012, monthIndex)
   const truncate = format === 'truncate'
 
-  return new Intl.DateTimeFormat('en-GB', {
+  let formattedMonth = new Intl.DateTimeFormat('en-GB', {
     month: truncate ? 'short' : 'long'
   }).format(date)
+
+  // Node.js uses four-letter abbreviation for September only, weirdly
+  formattedMonth = formattedMonth.replace('Sept', 'Sep')
+  return formattedMonth
 }
 
 module.exports = {

--- a/test/date.js
+++ b/test/date.js
@@ -299,4 +299,9 @@ describe('monthName', async () => {
     assert.equal(monthName(3, 'truncate'), 'Mar')
     assert.equal(monthName('3', 'truncate'), 'Mar')
   })
+
+  it('Truncates September to 3 letters', () => {
+    assert.equal(monthName(9, 'truncate'), 'Sep')
+    assert.equal(monthName('9', 'truncate'), 'Sep')
+  })
 })


### PR DESCRIPTION
[#89](https://github.com/x-govuk/govuk-prototype-filters/pull/89) updated `govukDate` to return the 3-letter abbreviation for September. However, this wasn’t applied to the `monthName` filter. To ensure consistency, this PR applies the same fix.