### PR TITLE
Add `showWeekday` option to `govukDate` and `govukDateTime`

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -161,6 +161,22 @@ Use the `truncate` option to use a truncated month name. Default is `false`.
 17 Aug 2021
 ```
 
+### `showWeekday`
+
+Use the `showWeekday` option to show the day of the week. Default is `false`.
+
+**Input**
+
+```njk
+{{ "2021-08-17T18:30:00" | govukDate(showWeekday=true) }}
+```
+
+**Output**
+
+```html
+Tuesday 17 August 2021
+```
+
 ---
 
 ## govukTime
@@ -307,6 +323,22 @@ Use the `truncate` option to use a truncated month name. Default is `false`.
 
 ```html
 17 Aug 2021 at 6:30pm
+```
+
+### `showWeekday`
+
+Use the `showWeekday` option to show the day of the week. Default is `false`.
+
+**Input**
+
+```njk
+{{ "2021-08-17T18:30:00" | govukDateTime(showWeekday=true) }}
+```
+
+**Output**
+
+```html
+Tuesday 17 August 2021 at 6:30pm
 ```
 
 ---

--- a/docs/date.md
+++ b/docs/date.md
@@ -128,20 +128,6 @@ Convert an ISO 8601 date string into a human readable date that follows [the GOV
 
 > This filter only outputs a date. If you want to output the date and time from an ISO 8601 date string, use [`govukDateTime`](#govukdatetime).
 
-You can also output a date with a truncated month:
-
-**Input**
-
-```njk
-{{ "2021-08-17" | govukDate("truncate") }}
-```
-
-**Output**
-
-```html
-17 Aug 2021
-```
-
 To get the today’s date, pass the special word `"today"` (or `"now"`):
 
 **Input**
@@ -154,6 +140,25 @@ This page was last updated on {{ "today" | govukDate }}.
 
 ```html
 This page was last updated on 21 October 2021.
+```
+
+### `truncate`
+
+Use the `truncate` option to use a truncated month name. Default is `false`.
+
+**Input**
+
+```njk
+{{ "2021-08-17" | govukDate(truncate=true) }}
+
+// "truncate" is deprecated, and will be removed in v2.0
+{{ 3 | govukDate("truncate") }}
+```
+
+**Output**
+
+```html
+17 Aug 2021
 ```
 
 ---
@@ -224,20 +229,6 @@ Convert an ISO 8601 date string into a human readable date and time that follows
 17 August 2021 at 6:30pm
 ```
 
-You can also output the time before the date:
-
-**Input**
-
-```njk
-{{ "2021-08-17T18:30:00" | govukDateTime("on") }}
-```
-
-**Output**
-
-```html
-6:30pm on 17 August 2021
-```
-
 To get the current date and time, pass the special word `"now"` (or `"today"`):
 
 **Input**
@@ -278,6 +269,44 @@ If only a time is given, only a time will be output:
 
 ```html
 6:30pm
+```
+
+### `timeFirst`
+
+Use the `timeFirst` option to show the time before the date. Default is `false`.
+
+**Input**
+
+```njk
+{{ "2021-08-17T18:30:00" | govukDateTime(timeFirst=true) }}
+
+// "on" is deprecated, and will be removed in v2.0
+{{ 3 | govukDateTime("on") }}
+```
+
+**Output**
+
+```html
+6:30pm on 17 August 2021
+```
+
+### `truncate`
+
+Use the `truncate` option to use a truncated month name. Default is `false`.
+
+**Input**
+
+```njk
+{{ "2021-08-17T18:30:00" | govukDateTime(truncate=true) }}
+
+// "truncate" is deprecated, and will be removed in v2.0
+{{ 3 | govukDateTime("truncate") }}
+```
+
+**Output**
+
+```html
+17 Aug 2021 at 6:30pm
 ```
 
 ---
@@ -385,11 +414,16 @@ Convert a number (between 1 and 12) into the name of the corresponding month.
 March
 ```
 
-You can also output a truncated month name:
+### `truncate`
+
+Use the `truncate` option to use a truncated month name:
 
 **Input**
 
 ```njk
+{{ 3 | monthName(truncate=true) }}
+
+// "truncate" is deprecated, and will be removed in v2.0
 {{ 3 | monthName("truncate") }}
 ```
 

--- a/lib/date.js
+++ b/lib/date.js
@@ -82,20 +82,39 @@ function duration(string, number, unit) {
  * @example <caption>Full date</caption>
  * govukDate('2021-08-17') // 17 August 2021
  * @example <caption>Full date (truncated)</caption>
+ * govukDate('2021-08-17', { truncate: true }) // 17 Aug 2021
  * govukDate('2021-08-17', 'truncate') // 17 Aug 2021
  * @example <caption>Month and year only</caption>
  * govukDate('2021-08') // August 2021
  * @example <caption>Month and year only (truncated)</caption>
+ * govukDate('2021-08', { truncate: true }) // Aug 2021
  * govukDate('2021-08', 'truncate') // Aug 2021
  * @example <caption>Today’s date</caption>
  * govukDate('today') // 21 October 2021
  * govukDate('today', 'truncate') // 21 Oct 2021
  * @param {string} string - Date
- * @param {boolean|string} [format] - Date format (currently accepts ‘truncate’)
+ * @param {object} [kwargs] - Keyword arguments
+ * @param {boolean} [kwargs.truncate] - Truncate month name
  * @returns {string} `string` as a human readable date
  */
-function govukDate(string, format = false) {
+function govukDate(string, kwargs) {
   string = normalize(string, '')
+
+  const options = {
+    truncate: false,
+    ...kwargs
+  }
+
+  /**
+  /* Support providing 'truncate' keyword instead of keyword arguments
+  /* @todo Deprecate keyword in next major release
+   */
+  if (typeof kwargs === 'string') {
+    options.truncate = kwargs === 'truncate'
+    console.warn(
+      `Passing 'truncate' to govukDate is deprecated. Use the truncate option instead. See https://x-govuk.github.io/govuk-prototype-filters/date/#govukdate`
+    )
+  }
 
   try {
     if (string === 'today' || string === 'now') {
@@ -104,13 +123,12 @@ function govukDate(string, format = false) {
 
     const isoDateRegex = /^\d{4}-(?:[0]\d|1[0-2])$/
     const dateHasNoDay = isoDateRegex.test(string)
-    const truncateDate = format === 'truncate'
     const date = DateTime.fromISO(string)
 
     // 2021-08 => August 2021
     // 2021-08 => Aug 2021 (truncated)
     if (dateHasNoDay) {
-      const tokens = truncateDate ? 'LLL yyyy' : 'LLLL yyyy'
+      const tokens = options.truncate ? 'LLL yyyy' : 'LLLL yyyy'
       let formattedDate = date.toFormat(tokens)
 
       // Node.js uses four-letter abbreviation for September only, weirdly
@@ -120,7 +138,7 @@ function govukDate(string, format = false) {
 
     // 2021-08-17 => 17 August 2021
     // 2021-08-17 => 17 Aug 2021 (truncated)
-    const preset = truncateDate ? 'DATE_MED' : 'DATE_FULL'
+    const preset = options.truncate ? 'DATE_MED' : 'DATE_FULL'
     let formattedDate = date.toLocaleString(DateTime[preset])
 
     // Node.js uses four-letter abbreviation for September only, weirdly
@@ -191,6 +209,7 @@ function govukTime(string) {
  * @example <caption>Full date and time</caption>
  * govukDateTime('2021-08-17T18:30:00') // 17 August 2021 at 6:30pm
  * @example <caption>Full time and date</caption>
+ * govukDateTime('2021-08-17', { timeFirst: true }) // 6:30pm on 17 August 2021
  * govukDateTime('2021-08-17', 'on') // 6:30pm on 17 August 2021
  * @example <caption>Date only</caption>
  * govukDateTime('2021-08-17') // 17 August 2021
@@ -199,23 +218,43 @@ function govukTime(string) {
  * @example <caption>The date and time now</caption>
  * govukDateTime('now') // 21 October 2021 at 10:45am
  * @param {string} string - Date
- * @param {boolean|string} [format] - Date format (currently accepts ‘on’)
+ * @param {object} [kwargs] - Keyword arguments
+ * @param {boolean} [kwargs.timeFirst] - Show time before date
+ * @param {boolean} [kwargs.truncate] - Truncate month name
  * @returns {string} `string` as a human readable date
  */
-function govukDateTime(string, format = false) {
+function govukDateTime(string, kwargs) {
   string = normalize(string, '')
 
   if (string === 'today' || string === 'now') {
     string = DateTime.now().toString()
   }
 
+  const options = {
+    timeFirst: false,
+    truncate: false,
+    ...kwargs
+  }
+
+  /**
+  /* Support providing 'on' keyword instead of keyword arguments
+  /* @todo Deprecate keyword in next major release
+   */
+  if (typeof kwargs === 'string') {
+    options.timeFirst = kwargs === 'on'
+    options.truncate = kwargs === 'truncate'
+    console.warn(
+      `Passing 'on' to govukDateTime is deprecated. Use the timeFirst option instead. See https://x-govuk.github.io/govuk-prototype-filters/date/#govukdatetime`
+    )
+  }
+
   const components = string.split('T')
   if (components.length === 2) {
     // Return date and time
-    const date = govukDate(components[0], format)
+    const date = govukDate(components[0], options)
     const time = govukTime(components[1])
 
-    return format === 'on' ? `${time} on ${date}` : `${date} at ${time}`
+    return options.timeFirst ? `${time} on ${date}` : `${date} at ${time}`
   } else if (string.includes(':')) {
     // Return time only
     return govukTime(string)
@@ -314,18 +353,35 @@ function isoDateFromDateInput(object, namePrefix) {
  *
  * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates}
  * @example month(3) // March
+ * @example month(3, { truncate: true }) // Mar
  * @example month(3, 'truncate') // Mar
  * @param {number|string} number - Value to convert
- * @param {boolean|string} [format] - Truncate name
+ * @param {object} [kwargs] - Keyword arguments
+ * @param {boolean} [kwargs.truncate] - Truncate month name
  * @returns {string} Month name
  */
-function monthName(number, format = false) {
+function monthName(number, kwargs) {
   const monthIndex = Number(number) - 1
   const date = new Date(2012, monthIndex)
-  const truncate = format === 'truncate'
+
+  const options = {
+    truncate: false,
+    ...kwargs
+  }
+
+  /**
+  /* Support providing 'on' keyword instead of keyword arguments
+  /* @todo Deprecate keyword in next major release
+   */
+  if (typeof kwargs === 'string') {
+    options.truncate = kwargs === 'truncate'
+    console.warn(
+      `Passing 'truncate' to monthName is deprecated. Use the truncate option instead. See https://x-govuk.github.io/govuk-prototype-filters/date/#monthname`
+    )
+  }
 
   let formattedMonth = new Intl.DateTimeFormat('en-GB', {
-    month: truncate ? 'short' : 'long'
+    month: options.truncate ? 'short' : 'long'
   }).format(date)
 
   // Node.js uses four-letter abbreviation for September only, weirdly

--- a/lib/date.js
+++ b/lib/date.js
@@ -81,6 +81,8 @@ function duration(string, number, unit) {
  * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates}
  * @example <caption>Full date</caption>
  * govukDate('2021-08-17') // 17 August 2021
+ * @example <caption>Full date (including day of the week)</caption>
+ * govukDate('2021-08-17', { showWeekday: true }) // Tuesday 17 August 2021
  * @example <caption>Full date (truncated)</caption>
  * govukDate('2021-08-17', { truncate: true }) // 17 Aug 2021
  * govukDate('2021-08-17', 'truncate') // 17 Aug 2021
@@ -94,6 +96,7 @@ function duration(string, number, unit) {
  * govukDate('today', 'truncate') // 21 Oct 2021
  * @param {string} string - Date
  * @param {object} [kwargs] - Keyword arguments
+ * @param {boolean} [kwargs.showWeekday] - Show day of the week
  * @param {boolean} [kwargs.truncate] - Truncate month name
  * @returns {string} `string` as a human readable date
  */
@@ -101,6 +104,7 @@ function govukDate(string, kwargs) {
   string = normalize(string, '')
 
   const options = {
+    showWeekday: false,
     truncate: false,
     ...kwargs
   }
@@ -117,29 +121,30 @@ function govukDate(string, kwargs) {
   }
 
   try {
+    let date
+    let dateHasNoDay
     if (string === 'today' || string === 'now') {
-      string = DateTime.now().toString()
+      date = new Date()
+    } else {
+      const isoDateRegex = /^\d{4}-(?:[0]\d|1[0-2])$/
+      dateHasNoDay = isoDateRegex.test(string)
+      date = DateTime.fromISO(string).toJSDate()
     }
-
-    const isoDateRegex = /^\d{4}-(?:[0]\d|1[0-2])$/
-    const dateHasNoDay = isoDateRegex.test(string)
-    const date = DateTime.fromISO(string)
 
     // 2021-08 => August 2021
     // 2021-08 => Aug 2021 (truncated)
-    if (dateHasNoDay) {
-      const tokens = options.truncate ? 'LLL yyyy' : 'LLLL yyyy'
-      let formattedDate = date.toFormat(tokens)
-
-      // Node.js uses four-letter abbreviation for September only, weirdly
-      formattedDate = formattedDate.replace(/Sept\s/, 'Sep ')
-      return formattedDate
-    }
-
     // 2021-08-17 => 17 August 2021
+    // 2021-08-17 => Tuesday 17 August 2021 (include day of the week)
     // 2021-08-17 => 17 Aug 2021 (truncated)
-    const preset = options.truncate ? 'DATE_MED' : 'DATE_FULL'
-    let formattedDate = date.toLocaleString(DateTime[preset])
+    // 2021-08-17 => Tues 17 Aug 2021 (include day of the week, truncated)
+    let formattedDate = new Intl.DateTimeFormat('en-GB', {
+      ...(options.showWeekday && {
+        weekday: options.truncate ? 'short' : 'long'
+      }),
+      year: 'numeric',
+      month: options.truncate ? 'short' : 'long',
+      ...(!dateHasNoDay && { day: 'numeric' })
+    }).format(date)
 
     // Node.js uses four-letter abbreviation for September only, weirdly
     formattedDate = formattedDate.replace(/Sept\s/, 'Sep ')
@@ -208,9 +213,14 @@ function govukTime(string) {
  *
  * @example <caption>Full date and time</caption>
  * govukDateTime('2021-08-17T18:30:00') // 17 August 2021 at 6:30pm
- * @example <caption>Full time and date</caption>
+ * @example <caption>Full date and time (with day of the week)</caption>
+ * govukDateTime('2021-08-17', { showWeekday: true })
+ * // Tuesday 17 August 2021 at 6:30pm
+ * @example <caption>Full date and time (time first)</caption>
  * govukDateTime('2021-08-17', { timeFirst: true }) // 6:30pm on 17 August 2021
  * govukDateTime('2021-08-17', 'on') // 6:30pm on 17 August 2021
+ * @example <caption>Full date and time (truncated)</caption>
+ * govukDateTime('2021-08-17', { truncated: true }) // 17 Aug 2021 at 6:30pm
  * @example <caption>Date only</caption>
  * govukDateTime('2021-08-17') // 17 August 2021
  * @example <caption>Time only</caption>
@@ -219,6 +229,7 @@ function govukTime(string) {
  * govukDateTime('now') // 21 October 2021 at 10:45am
  * @param {string} string - Date
  * @param {object} [kwargs] - Keyword arguments
+ * @param {boolean} [kwargs.showWeekday] - Show day of the week
  * @param {boolean} [kwargs.timeFirst] - Show time before date
  * @param {boolean} [kwargs.truncate] - Truncate month name
  * @returns {string} `string` as a human readable date

--- a/test/date.js
+++ b/test/date.js
@@ -83,6 +83,20 @@ describe('Date filters', async () => {
     assert.equal(govukDate('2021-08', 'truncate'), 'Aug 2021')
   })
 
+  it('Converts ISO 8601 date time with day of the week', () => {
+    assert.equal(
+      govukDate('2021-08-17T12:00:00', { showWeekday: true }),
+      'Tuesday 17 August 2021'
+    )
+    assert.equal(
+      govukDate('2021-08-17T12:00:00', {
+        showWeekday: true,
+        truncate: true
+      }),
+      'Tue, 17 Aug 2021'
+    )
+  })
+
   it('Converts keyword to a date using the GOV.UK style', (context) => {
     // Mock now as 29 January 2025 at 5:30pm
     context.mock.timers.enable({ apis: ['Date'], now: 1738171800000 })
@@ -163,6 +177,27 @@ describe('govukDateTime', async () => {
     assert.equal(
       govukDateTime('2021-08-17T18:30:00', 'truncate'),
       '17 Aug 2021 at 6:30pm'
+    )
+  })
+
+  it('Converts ISO 8601 date time to date time with day of the week', () => {
+    assert.equal(
+      govukDateTime('2021-08-17T12:00:00', { showWeekday: true }),
+      'Tuesday 17 August 2021 at 12pm (midday)'
+    )
+    assert.equal(
+      govukDateTime('2021-08-17T12:00:00', {
+        showWeekday: true,
+        timeFirst: true
+      }),
+      '12pm (midday) on Tuesday 17 August 2021'
+    )
+    assert.equal(
+      govukDateTime('2021-08-17T12:00:00', {
+        showWeekday: true,
+        truncate: true
+      }),
+      'Tue, 17 Aug 2021 at 12pm (midday)'
     )
   })
 

--- a/test/date.js
+++ b/test/date.js
@@ -64,9 +64,22 @@ describe('duration', async () => {
 
 describe('Date filters', async () => {
   it('Converts ISO 8601 date time to a date using the GOV.UK style', () => {
+    assert.equal(govukDate('2021-08-17T12:00:00'), '17 August 2021')
     assert.equal(govukDate('2021-08-17'), '17 August 2021')
-    assert.equal(govukDate('2021-08-17', 'truncate'), '17 Aug 2021')
     assert.equal(govukDate('2021-08'), 'August 2021')
+  })
+
+  it('Converts ISO 8601 date time to a truncated date', () => {
+    assert.equal(
+      govukDate('2021-08-17T12:00:00', { truncate: true }),
+      '17 Aug 2021'
+    )
+    assert.equal(govukDate('2021-08-17', { truncate: true }), '17 Aug 2021')
+    assert.equal(govukDate('2021-08', { truncate: true }), 'Aug 2021')
+
+    // Using deprecated string parameter
+    assert.equal(govukDate('2021-08-17T12:00:00', 'truncate'), '17 Aug 2021')
+    assert.equal(govukDate('2021-08-17', 'truncate'), '17 Aug 2021')
     assert.equal(govukDate('2021-08', 'truncate'), 'Aug 2021')
   })
 
@@ -79,8 +92,8 @@ describe('Date filters', async () => {
   })
 
   it('Truncates September to 3 letters', () => {
-    assert.equal(govukDate('2024-09-21', 'truncate'), '21 Sep 2024')
-    assert.equal(govukDate('2024-09', 'truncate'), 'Sep 2024')
+    assert.equal(govukDate('2024-09-21', { truncate: true }), '21 Sep 2024')
+    assert.equal(govukDate('2024-09', { truncate: true }), 'Sep 2024')
   })
 
   it('Returns error converting ISO 8601 date to date with GOV.UK style', () => {
@@ -116,10 +129,6 @@ describe('govukDateTime', async () => {
       '17 August 2021 at 6:30pm'
     )
     assert.equal(
-      govukDateTime('2021-08-17T18:30:00', 'on'),
-      '6:30pm on 17 August 2021'
-    )
-    assert.equal(
       govukDateTime('2021-08-17T00:00:59'),
       '17 August 2021 at 12am (midnight)'
     )
@@ -131,14 +140,46 @@ describe('govukDateTime', async () => {
     assert.equal(govukDateTime('18:30'), '6:30pm')
   })
 
+  it('Converts ISO 8601 date time to date time with time first', () => {
+    assert.equal(
+      govukDateTime('2021-08-17T18:30:00', { timeFirst: true }),
+      '6:30pm on 17 August 2021'
+    )
+
+    // Using deprecated string parameter
+    assert.equal(
+      govukDateTime('2021-08-17T18:30:00', 'on'),
+      '6:30pm on 17 August 2021'
+    )
+  })
+
+  it('Converts ISO 8601 date time to date time with truncated date', () => {
+    assert.equal(
+      govukDateTime('2021-08-17T18:30:00', { truncate: true }),
+      '17 Aug 2021 at 6:30pm'
+    )
+
+    // Using deprecated string parameter
+    assert.equal(
+      govukDateTime('2021-08-17T18:30:00', 'truncate'),
+      '17 Aug 2021 at 6:30pm'
+    )
+  })
+
   it('Converts keyword to date time with the GOV.UK style', (context) => {
     // Mock now as 29 January 2025 at 5:30pm
     context.mock.timers.enable({ apis: ['Date'], now: 1738171800000 })
 
     assert.equal(govukDateTime('now'), '29 January 2025 at 5:30pm')
-    assert.equal(govukDateTime('now', 'on'), '5:30pm on 29 January 2025')
+    assert.equal(
+      govukDateTime('now', { timeFirst: true }),
+      '5:30pm on 29 January 2025'
+    )
     assert.equal(govukDateTime('today'), '29 January 2025 at 5:30pm')
-    assert.equal(govukDateTime('today', 'on'), '5:30pm on 29 January 2025')
+    assert.equal(
+      govukDateTime('today', { timeFirst: true }),
+      '5:30pm on 29 January 2025'
+    )
   })
 
   it('Returns error converting an ISO 8601 date time to date time using the GOV.UK style', () => {
@@ -296,6 +337,13 @@ describe('monthName', async () => {
   it('Converts number into name of corresponding month.', () => {
     assert.equal(monthName(3), 'March')
     assert.equal(monthName('3'), 'March')
+  })
+
+  it('Converts number into truncated name of corresponding month.', () => {
+    assert.equal(monthName(3, { truncate: true }), 'Mar')
+    assert.equal(monthName('3', { truncate: true }), 'Mar')
+
+    // Using deprecated string parameter
     assert.equal(monthName(3, 'truncate'), 'Mar')
     assert.equal(monthName('3', 'truncate'), 'Mar')
   })


### PR DESCRIPTION
Adds a new `showWeekday` option to `govukDate` and `govukDateTime`:

```njk
{{ "2021-08-17T18:30:00" | govukDate(showWeekday=true) }}
{{ "2021-08-17T18:30:00" | govukDateTime(showWeekday=true) }}
```

```html
Tuesday 17 August 2021
Tuesday 17 August 2021 at 6:30pm
```

As these filters need to accept more options, I’ve changed to using [keyword arguments](https://mozilla.github.io/nunjucks/templating.html#keyword-arguments), while maintaining support for the previous single keyword options. For example:

```njk
Old: {{ "2021-08-17" | govukDate("truncate") }}
New: {{ "2021-08-17" | govukDate(truncate=true) }}

Old: {{ "2021-08-17T18:30:00" | govukDateTime("on") }}
New: {{ "2021-08-17T18:30:00" | govukDateTime(timeFirst=true) }}
```

```html
Old: 17 Aug 2021
New: 17 Aug 2021

Old: 6:30pm on 17 August 2021
New: 6:30pm on 17 August 2021
```

However, while the previous methods are supported, using multiple options requires using keyword arguments:

```njk
{{ "2021-08-17T18:30:00" | govukDateTime(timeFirst=true, showWeekday=true) }}
{{ "2021-08-17T18:30:00" | govukDateTime(timeFirst=true, truncate=true, showWeekday=true) }}
```

```html
6:30pm on Tuesday 17 August 2021
6:30pm on Tue, 17 Aug 2021
```

From v1.5.0, the previous options will be depreciated, before removal in v2.0. Therefore:

- Documentation shows the new options, with examples showing the deprecated methods and noting that they will be removed in v2.0
- Warnings are sent to the console if the previous methods are used
- JSDoc should mean type warnings appear in IDEs that support type checking

Finally, this PR ensures `Intl.DateTimeFormat` is used exclusively for formatting dates, as opposed to this and a mix of this and Luxon’s date time formatting methods.