### PR TITLE
Add `age` date filter

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -7,6 +7,29 @@ title: Date filters
 
 [[toc]]
 
+## age
+
+Return a person’s age, with reference to [the NHS.UK content guide](https://service-manual.nhs.uk/content/inclusive-content/age).
+
+If the birth date is less than 2 years ago, the age is returned in months. If the birth date is less than 6 months ago, the age is returned in weeks.
+
+**Input**
+
+```njk
+{# Current datetime is 2025-02-14T12:00:00 #}
+{{ "2025-02-06" | age }}
+{{ "2024-02-14" | age }}
+{{ "2020-02-14" | age }}
+```
+
+**Output**
+
+```html
+2 weeks
+12 months
+5 years
+```
+
 ## daysAgo
 
 Return how many days ago a date was.

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,10 +1,63 @@
 const { views } = require('govuk-prototype-kit')
 const { DateTime, Duration, Settings } = require('luxon')
 
+const { plural } = require('./number.js')
 const { normalize } = require('./utils.js')
 
 Settings.defaultLocale = 'en-GB'
 Settings.throwOnInvalid = true
+
+/**
+ * Returns a person’s age with reference to the NHS.UK content guide
+ * Returns weeks until 6 months old.
+ * Returns months until 2 years old.
+ * Returns years above 2 years old.
+ *
+ * @see {@link https://service-manual.nhs.uk/content/inclusive-content/age}
+ * @param {string} string - Date
+ * @returns {string} Age in weeks, months or years
+ */
+function age(string) {
+  string = normalize(string, '')
+
+  try {
+    const date = new Date(string)
+
+    if (Number.isNaN(Date.parse(string))) {
+      throw new Error('Invalid DateTime')
+    }
+
+    const today = new Date()
+    const ageMs = today.valueOf() - date.valueOf()
+
+    // Return age in weeks, if less than 6 months old
+    const ageDays = ageMs / (1000 * 60 * 60 * 24)
+    if (ageDays > 0 && ageDays < 183) {
+      let ageWeeks = Math.floor(ageDays / 7)
+
+      // If less than a week old, return 1 week
+      ageWeeks = ageWeeks === 0 ? 1 : ageWeeks
+
+      return plural(ageWeeks, 'week')
+    }
+
+    // Return age in months, if less than 2 years old
+    const ageMonths =
+      (today.getFullYear() - date.getFullYear()) * 12 +
+      (today.getMonth() - date.getMonth()) -
+      (today.getDate() < date.getDate() ? 1 : 0)
+    if (ageMonths < 24) {
+      return `${ageMonths} months`
+    }
+
+    // Return age if over 2 years old
+    const ageYears = Math.floor(ageMs / 3.15576e10)
+
+    return `${ageYears} years`
+  } catch (error) {
+    return error.message
+  }
+}
 
 /**
  * Returns number of days ago from the given date.
@@ -23,8 +76,8 @@ Settings.throwOnInvalid = true
  */
 function daysAgo(string) {
   const timeZone = 'Europe/London'
-
   string = normalize(string, '')
+
   try {
     const date = DateTime.fromISO(string, { zone: timeZone })
     const today = DateTime.now().setZone(timeZone)
@@ -56,6 +109,7 @@ function daysAgo(string) {
 function duration(string, number, unit) {
   const timeZone = 'Europe/London'
   string = normalize(string, '')
+
   try {
     if (string === 'today' || string === 'now') {
       string = DateTime.now().setZone(timeZone).toString()
@@ -401,6 +455,7 @@ function monthName(number, kwargs) {
 }
 
 module.exports = {
+  age,
   daysAgo,
   duration,
   govukDate,
@@ -411,6 +466,7 @@ module.exports = {
 }
 
 // Add date filters to GOV.UK Prototype Kit
+views.addFilter('age', age)
 views.addFilter('daysAgo', daysAgo)
 views.addFilter('duration', duration)
 views.addFilter('govukDate', govukDate)

--- a/test/date.js
+++ b/test/date.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('node:test')
 
 const {
+  age,
   daysAgo,
   duration,
   govukDate,
@@ -10,6 +11,53 @@ const {
   isoDateFromDateInput,
   monthName
 } = require('../lib/date.js')
+
+describe('age', async () => {
+  it('Returns an age in weeks, until 6 months', (context) => {
+    // Mock now as 15 October 2025 at 10:00am
+    context.mock.timers.enable({ apis: ['Date'], now: 1760522400000 })
+
+    assert.equal(age('2025-10-14'), '1 week') // 1 day old
+    assert.equal(age('2025-10-02'), '1 week') // 13 days old
+    assert.equal(age('2025-10-01'), '2 weeks') // 14 days old
+    assert.equal(age('2025-09-14'), '4 weeks')
+  })
+
+  it('Returns an age in months, until 2 years', (context) => {
+    // Mock now as 15 October 2025 at 10:00am
+    context.mock.timers.enable({ apis: ['Date'], now: 1760522400000 })
+
+    // Before 6 month birthday
+    assert.equal(age('2025-04-16'), '26 weeks')
+
+    // On 6 month birthday
+    assert.equal(age('2025-04-15'), '6 months')
+  })
+
+  it('Returns an age in years', (context) => {
+    // Mock now as 15 October 2025 at 10:00am
+    context.mock.timers.enable({ apis: ['Date'], now: 1760522400000 })
+
+    // Before second birthday
+    assert.equal(age('2023-10-16'), '23 months')
+
+    // On second birthday
+    assert.equal(age('2023-10-15'), '2 years')
+
+    // Before third birthday
+    assert.equal(age('2022-10-16'), '2 years')
+
+    // On third birthday
+    assert.equal(age('2022-10-15'), '3 years')
+
+    // After third birthday
+    assert.equal(age('2022-10-14'), '3 years')
+  })
+
+  it('Returns error if date can’t be parsed', () => {
+    assert.equal(age('2024-12-32'), 'Invalid DateTime')
+  })
+})
 
 describe('daysAgo', async () => {
   it('Returns correct number of days ago', () => {


### PR DESCRIPTION
Return a person’s age, with reference to [the NHS.UK content guide](https://service-manual.nhs.uk/content/inclusive-content/age).

If the birth date is less than 2 years ago, the age is returned in months. If the birth date is less than 6 months ago, the age is returned in weeks.

**Input**

```njk
{# Current datetime is 2025-02-14T12:00:00 #}
{{ "2025-02-06" | age }}
{{ "2024-02-14" | age }}
{{ "2020-02-14" | age }}
```

**Output**

```html
2 weeks
12 months
5 years
```