### PR TITLE
Add support for `at` argument on `age` filter

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -30,6 +30,22 @@ If the birth date is less than 2 years ago, the age is returned in months. If th
 5 years
 ```
 
+### `at`
+
+Use the `at` option to provide a reference date from which to calculate a person’s age. Default is today’s date.
+
+**Input**
+
+```njk
+{{ "2000-01-25" | age(at=2025-01-25) }}
+```
+
+**Output**
+
+```html
+25 years
+```
+
 ## daysAgo
 
 Return how many days ago a date was.

--- a/lib/date.js
+++ b/lib/date.js
@@ -15,10 +15,14 @@ Settings.throwOnInvalid = true
  *
  * @see {@link https://service-manual.nhs.uk/content/inclusive-content/age}
  * @param {string} string - Date
+ * @param {object} [kwargs] - Keyword arguments
  * @returns {string} Age in weeks, months or years
  */
-function age(string) {
+function age(string, kwargs) {
   string = normalize(string, '')
+  const options = {
+    ...kwargs
+  }
 
   try {
     const date = new Date(string)
@@ -27,8 +31,8 @@ function age(string) {
       throw new Error('Invalid DateTime')
     }
 
-    const today = new Date()
-    const ageMs = today.valueOf() - date.valueOf()
+    const comparisonDate = options.at ? new Date(options.at) : new Date()
+    const ageMs = comparisonDate.valueOf() - date.valueOf()
 
     // Return age in weeks, if less than 6 months old
     const ageDays = ageMs / (1000 * 60 * 60 * 24)
@@ -43,9 +47,9 @@ function age(string) {
 
     // Return age in months, if less than 2 years old
     const ageMonths =
-      (today.getFullYear() - date.getFullYear()) * 12 +
-      (today.getMonth() - date.getMonth()) -
-      (today.getDate() < date.getDate() ? 1 : 0)
+      (comparisonDate.getFullYear() - date.getFullYear()) * 12 +
+      (comparisonDate.getMonth() - date.getMonth()) -
+      (comparisonDate.getDate() < date.getDate() ? 1 : 0)
     if (ageMonths < 24) {
       return `${ageMonths} months`
     }

--- a/test/date.js
+++ b/test/date.js
@@ -54,6 +54,10 @@ describe('age', async () => {
     assert.equal(age('2022-10-14'), '3 years')
   })
 
+  it('Takes an optional `at` keyword argument', () => {
+    assert.equal(age('2000-01-25', { at: '2025-01-25' }), '25 years')
+  })
+
   it('Returns error if date can’t be parsed', () => {
     assert.equal(age('2024-12-32'), 'Invalid DateTime')
   })


### PR DESCRIPTION
This makes it possible to return the age of a given date of birth on a specific date.

Useful if needing to show how old someone was when a particular event happened in the past (or future).