### PR TITLE
Make `isoDateFromDateInput` work with number values

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -355,7 +355,7 @@ const ALLOWED_VALUES_FOR_MONTHS = [
  */
 function parseMonth(input) {
   if (input == null) return undefined
-  const trimmedLowerCaseInput = input.trim().toLowerCase()
+  const trimmedLowerCaseInput = String(input).trim().toLowerCase()
   return ALLOWED_VALUES_FOR_MONTHS.find((month) =>
     month.find((allowedValue) => allowedValue === trimmedLowerCaseInput)
   )?.[0]

--- a/test/date.js
+++ b/test/date.js
@@ -289,6 +289,17 @@ describe('isoDateFromDateInput', async () => {
     )
   })
 
+  it('Converts an object with date values as numbers to ISO 8601 date', () => {
+    assert.equal(
+      isoDateFromDateInput({
+        day: 1,
+        month: 2,
+        year: 2012
+      }),
+      '2012-02-01'
+    )
+  })
+
   it('Converts `govukDateInput` values with a full-length word for the month to ISO 8601 date', () => {
     assert.equal(
       isoDateFromDateInput({


### PR DESCRIPTION
Currently if you do this:

```njk
 {{ {"day": "1", "month": "2", "year": "2020"} | isoDateFromDateInput }}
```

you get an error:

```
TypeError: input.trim is not a function
```

This allows the filter to also work where the day, month and year values are numbers, as well as strings.